### PR TITLE
Add logstasher config for JSON logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '4.1.2'
 gem 'rails-api', '0.2.1'
+gem 'logstasher', '0.5.3'
 
 group :development, :test do
   gem 'rspec-rails', '3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,10 @@ GEM
     hike (1.2.3)
     i18n (0.6.9)
     json (1.8.1)
+    logstash-event (1.1.5)
+    logstasher (0.5.3)
+      logstash-event (~> 1.1.0)
+      request_store
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -64,6 +68,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
+    request_store (1.0.6)
     rspec-core (3.0.1)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.1)
@@ -109,6 +114,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  logstasher (= 0.5.3)
   rails (= 4.1.2)
   rails-api (= 0.2.1)
   rspec-rails (= 3.0.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,11 @@ module HmrcManualsApi
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    # We need to put this middleware back, after "rails-api" strips it out.
+    # This middleware must be present, otherwise the "request_store" gem, which
+    # is a dependency of "logstasher", falls over. It's not clear whether "request_store"
+    # actually uses this middleware itself, but it references it in the railtie.
+    config.middleware.insert_after(Rack::Runtime, Rack::MethodOverride)
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,4 +65,8 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
+
+  config.logstasher.enabled = true
+  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  config.logstasher.suppress_app_log = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,8 @@
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
+    # Pass request Id to logging
+    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
+  end
+end


### PR DESCRIPTION
This change involves adding back a rack middleware that was stripped
out by `rails-api`.
