### PR TITLE
Add ci_reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /tmp
 
 /coverage
+/spec/reports

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,6 @@ group :development, :test do
   gem 'rspec-rails', '3.0.1'
   gem 'simplecov', '0.8.2', require: false
   gem 'simplecov-rcov', '0.2.3', require: false
+  gem 'ci_reporter', '2.0.0.alpha2'
+  gem 'ci_reporter_rspec', '0.0.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,11 @@ GEM
       multi_json
     arel (5.0.1.20140414130214)
     builder (3.2.2)
+    ci_reporter (2.0.0.alpha2)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (0.0.2)
+      ci_reporter (= 2.0.0.alpha2)
+      rspec (>= 2.14, < 4)
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
@@ -74,6 +79,10 @@ GEM
     raindrops (0.13.0)
     rake (10.3.2)
     request_store (1.0.6)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
     rspec-core (3.0.1)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.1)
@@ -124,6 +133,8 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 3.1.15)
+  ci_reporter (= 2.0.0.alpha2)
+  ci_reporter_rspec (= 0.0.2)
   logstasher (= 0.5.3)
   rails (= 4.1.2)
   rails-api (= 0.2.1)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -5,4 +5,4 @@ set -e
 export RAILS_ENV=test
 git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-bundle exec rake --trace
+bundle exec rake ci:setup:rspec default --trace

--- a/lib/tasks/ci_reporter.rake
+++ b/lib/tasks/ci_reporter.rake
@@ -1,0 +1,3 @@
+if Rails.env.development? or Rails.env.test?
+  require 'ci/reporter/rake/rspec'
+end


### PR DESCRIPTION
This translates the `rspec` results into JUnit XML that Jenkins can
consume and graph for each build.

The alpha version of `ci_reporter` is used here because the current release
(1.9.2) throws deprecation warnings with `rspec 3`, whereas the alpha version seems to work perfectly.
