### PR TITLE
Add spec for malformed JSON

### DIFF
--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "validation" do
+  let(:malformed_json) { "[" }
+  let(:headers) { { 'Content-Type' => 'application/json' } }
+
+  context "for manuals" do
+    it "detects malformed JSON" do
+      expect { put '/hmrc-manuals/imaginary-slug', malformed_json, headers }.to raise_exception(
+        # This exception will translate to a 400 status code.
+        ActionDispatch::ParamsParser::ParseError
+      )
+    end
+  end
+
+  context "for manual sections" do
+    it "detects malformed JSON" do
+      expect { put '/hmrc-manuals/imaginary-slug/imaginary-section', malformed_json, headers }.to raise_exception(
+        # This exception will translate to a 400 status code.
+        ActionDispatch::ParamsParser::ParseError
+      )
+    end
+  end
+end


### PR DESCRIPTION
The default rails middleware (`ActionDispatch::ParamsParser`) handles malformed
JSON in the way that we need (returning status code 400). The only nuance is
that the rails testing hooks appear to raise exceptions rather than return 400
in this case, making the spec less clear than it could be.
