### PR TITLE
Manually parse JSON in requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::API
+
+private
+  def parse_request_body
+    @parsed_request_body = JSON.parse(request.body.read)
+  rescue JSON::ParserError => e
+    message = "Request JSON could not be parsed: #{e.message}"
+    render json: { status: "error", errors: [message] }, status: 400
+  end
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -1,8 +1,10 @@
 class ManualsController < ApplicationController
+  before_filter :parse_request_body, only: [:update]
+
   def update
     validation_errors = JSON::Validator.fully_validate(
       MANUAL_SCHEMA,
-      manual_params,
+      @parsed_request_body,
       validate_schema: true
     )
     if validation_errors.empty?
@@ -10,10 +12,5 @@ class ManualsController < ApplicationController
     else
       render json: { status: "error", errors: validation_errors }, status: 422
     end
-  end
-
-  private
-  def manual_params
-    params.permit(:title)
   end
 end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,8 +1,10 @@
 class SectionsController < ApplicationController
+  before_filter :parse_request_body, only: [:update]
+
   def update
     validation_errors = JSON::Validator.fully_validate(
       SECTION_SCHEMA,
-      section_params,
+      @parsed_request_body,
       validate_schema: true
     )
     if validation_errors.empty?
@@ -10,10 +12,5 @@ class SectionsController < ApplicationController
     else
       render json: { status: "error", errors: validation_errors }, status: 422
     end
-  end
-
-  private
-  def section_params
-    params.permit(:title)
   end
 end

--- a/config/initializers/disable_params_parser.rb
+++ b/config/initializers/disable_params_parser.rb
@@ -1,0 +1,13 @@
+# We're doing our own JSON parsing, and error handling.
+# If this is in place it causes several problems:
+#
+# Firstly, it pollutes the params hash with data from the json request, which
+# leads to confusion when there is a param in the routes and in the json.
+#
+# Secondly, when given invalid json, it blows up before even reaching the
+# application, preventing us from handling invalid json gracefully.
+#
+# Thirdly, empty arrays are converted to nil, which is not compatible with
+# validation against the schema - we want to require a given key, but allow the
+# value to be an empty array.
+Rails.application.config.middleware.delete "ActionDispatch::ParamsParser"

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -7,10 +7,11 @@ describe "validation" do
 
   context "for manuals" do
     it "detects malformed JSON" do
-      expect { put '/hmrc-manuals/imaginary-slug', malformed_json, headers }.to raise_exception(
-        # This exception will translate to a 400 status code.
-        ActionDispatch::ParamsParser::ParseError
-      )
+      put '/hmrc-manuals/imaginary-slug', malformed_json, headers
+
+      expect(response.status).to eq(400)
+      expect(json_response).to include("status" => "error")
+      expect(json_response["errors"].first).to match(%r{Request JSON could not be parsed:})
     end
 
     it "validates for the presence of the title" do
@@ -24,10 +25,11 @@ describe "validation" do
 
   context "for manual sections" do
     it "detects malformed JSON" do
-      expect { put '/hmrc-manuals/imaginary-slug/sections/imaginary-section', malformed_json, headers }.to raise_exception(
-        # This exception will translate to a 400 status code.
-        ActionDispatch::ParamsParser::ParseError
-      )
+      put '/hmrc-manuals/imaginary-slug/sections/imaginary-section', malformed_json, headers
+
+      expect(response.status).to eq(400)
+      expect(json_response).to include("status" => "error")
+      expect(json_response["errors"].first).to match(%r{Request JSON could not be parsed:})
     end
 
     it "validates for the presence of the title" do


### PR DESCRIPTION
This means that handling of parse errors won't trigger exception emails and is
consistent/predictable across environments.

It also means that empty arrays, for example, aren't converted to nil, which
was making validating against a schema harder.

We are no longer using strong params to limit the params that are processed.
Filtering supplied parameters will be a concern when we come to send data to
Content Store, but isn't yet.
