### PR TITLE
Remove titles from breadcrumbs

### DIFF
--- a/json_examples/requests/employment-income-manual/EIM25525.json
+++ b/json_examples/requests/employment-income-manual/EIM25525.json
@@ -16,12 +16,10 @@
     // of the sections in between, from left to right.
     "breadcrumbs": [
       {
-        "section_id": "EIM23000",
-        "title": "The grandparent section. Child to the manual."
+        "section_id": "EIM23000" // The grandparent section. Child to the manual.
       },
       {
-        "section_id": "EIM25500",
-        "title": "The immediate parent section."
+        "section_id": "EIM25500" // The immediate parent section.
       }
     ],
     "child_section_groups": []

--- a/json_examples/send_to_content_store/section.json
+++ b/json_examples/send_to_content_store/section.json
@@ -15,8 +15,7 @@
     "breadcrumbs": [
       {
         "base_path": "/guidance/employment-income-manual/EIM0000",
-        "title": "Something something",
-        "section_id": "EIM0000" // omitted for normal manuals
+        "section_id": "EIM0000" // a normal manual would have a title instead
       }
     ],
     "child_section_groups": [

--- a/public/section-schema.json
+++ b/public/section-schema.json
@@ -62,14 +62,10 @@
             "type": "object",
             "additionalProperties": false,
             "required": [
-              "section_id",
-              "title"
+              "section_id"
             ],
             "properties": {
               "section_id": {
-                "type": "string"
-              },
-              "title": {
                 "type": "string"
               }
             }

--- a/spec/support/test_data_helpers.rb
+++ b/spec/support/test_data_helpers.rb
@@ -64,8 +64,7 @@ module TestDataHelpers
         },
         breadcrumbs: [
           {
-            section_id: '1234',
-            title: 'A section higher up the tree'
+            section_id: '1234'
           }
         ],
         child_section_groups: [


### PR DESCRIPTION
We added this speculatively because we thought it might allow a better user
experience when looking at a long chain of breadcrumbs - it could be included
as the link's title.

Feedback from HMRC/their development team at iO1 is that updating a section
title near the top of the hierarchy could trigger hundreds of requests to
update every child section in the tree. The trade-off doesn't seem worth it.
