### PR TITLE
Update example section's child section descriptions

### DIFF
--- a/json_examples/requests/employment-income-manual/EIM11200.json
+++ b/json_examples/requests/employment-income-manual/EIM11200.json
@@ -17,12 +17,12 @@
           {
             "section_id": "EIM11205",
             "title": "Incentive award schemes:\n\ntax liability on incentive awards",
-            "description": "### General\n\nWhere an employer meets the tax payable on a non-cash incentive\naward given to a direct employee by entering into a PAYE settlement\nagreement (PSA), the award is not chargeable to tax on the\nemployee. PSAs cannot be used to pay the tax on cash incentive\nawards. PSAs are covered at\n[EIM11270](/guidance/employment-income-manual/EIM11200#EIM11270).\n\nApart from non-cash awards covered by a PSA, all incentive\nawards made to employees are chargeable on them as employment\nincome.\n\n### Cash awards\n\nIn the case of cash awards the amount chargeable as earnings is\nthe amount of the award.\n\n### Non-cash awards\n\nIn the case of non-cash awards the amount chargeable depends\nupon the nature of the award:\n\n*   where awards are obtained through the use of\nvouchers, the charge for all employees is the full cost to the\nprovider of making the award (see[EIM16140](/guidance/employment-income-manual/EIM16140))\n\n*   for directors and employees within the benefits\n\n    code (see\n    [EIM20100](/guidance/employment-income-manual/EIM20001#EIM20100) to EIM20102) the charge is the\n\n    full cost to the provider of making the award\n*   for employees who are in an excluded employment (\n\n    [EIM20007](/guidance/employment-income-manual/EIM20001#EIM20007)) the charge is the second-hand\n\n    value of the award if it can be converted into money (see\n    [EIM00540](/guidance/employment-income-manual/EIM00505#EIM00540) to EIM00560)."
+            "description": "Optional"
           },
           {
             "section_id": "EIM11210",
             "title": "Incentive award schemes:\n\nawards to an employee's family or dependants",
-            "description": "Awards are treated as made to the employee if they are received\nby members of the employee's family or household. There are\ndifferent definitions of the family circle depending upon whether\nvouchers are used, or awards are obtained in some other way and are\nchargeable under the benefits code."
+            "description": "Optional"
           }
         ]
       }


### PR DESCRIPTION
The descriptions which were initially added here were the bodies of
the child sections, which looked misleading. As far as we know, no
HMRC manual sections have descriptions so this field is optional.
If it is present, it should be a short description of the section's
content.
