### PR TITLE
Explicitly require GdsApi exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'gds_api/exceptions'
+
 class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
 


### PR DESCRIPTION
This should fix the inability of the app to boot in production mode.

The error was:

```
E, [2014-07-31T12:35:52.909346 #5488] ERROR -- : uninitialized constant GdsApi::BaseError (NameError)
/data/vhost/hmrc-manuals-api.preview.alphagov.co.uk/releases/20140731100352/app/controllers/application_controller.rb:6:in `<class:ApplicationController>'
/data/vhost/hmrc-manuals-api.preview.alphagov.co.uk/releases/20140731100352/app/controllers/application_controller.rb:1:in `<top (required)>'
```
