### PR TITLE
Using inflections, correctly capitalize API as it's an acronym

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -14,12 +14,12 @@ class Manual
   end
 
   def publishing_api_manual
-    PublishingApiManual.new(self)
+    PublishingAPIManual.new(self)
   end
 
   def save!
     api = GdsApi::PublishingApi.new(Plek.current.find('publishing-api'))
-    api.put_content_item(PublishingApiManual.base_path(@slug),
+    api.put_content_item(PublishingAPIManual.base_path(@slug),
                          publishing_api_manual.to_h)
   end
 

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -1,7 +1,7 @@
 require 'active_model'
 require 'struct_with_rendered_markdown'
 
-class PublishingApiManual
+class PublishingAPIManual
   include ActiveModel::Validations
 
   validates :to_h, no_dangerous_html_in_text_fields: true
@@ -13,11 +13,11 @@ class PublishingApiManual
 
   def to_h
     enriched_data = @manual_attributes.clone.merge({
-      base_path: PublishingApiManual.base_path(@slug),
+      base_path: PublishingAPIManual.base_path(@slug),
       format: 'hmrc-manual',
       publishing_app: 'hmrc-manuals-api',
       rendering_app: 'manuals-frontend',
-      routes: [{ path: PublishingApiManual.base_path(@slug), type: :exact }]
+      routes: [{ path: PublishingAPIManual.base_path(@slug), type: :exact }]
       })
     enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
     add_base_path_to_child_section_groups(enriched_data)
@@ -31,7 +31,7 @@ private
   def add_base_path_to_child_section_groups(attributes)
     attributes["details"]["child_section_groups"].each do |section_group|
       section_group["child_sections"].each do |section|
-        section['base_path'] = PublishingApiSection.base_path(@slug, section['section_id'])
+        section['base_path'] = PublishingAPISection.base_path(@slug, section['section_id'])
       end
     end
     attributes

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -1,6 +1,6 @@
 require 'struct_with_rendered_markdown'
 
-class PublishingApiSection
+class PublishingAPISection
   include ActiveModel::Validations
 
   validates :to_h, no_dangerous_html_in_text_fields: true
@@ -13,11 +13,11 @@ class PublishingApiSection
 
   def to_h
     enriched_data = @section_attributes.clone.merge({
-      base_path: PublishingApiSection.base_path(@manual_slug, @section_id),
+      base_path: PublishingAPISection.base_path(@manual_slug, @section_id),
       format: 'hmrc-manual-section',
       publishing_app: 'hmrc-manuals-api',
       rendering_app: 'manuals-frontend',
-      routes: [{ path: PublishingApiSection.base_path(@manual_slug, @section_id), type: :exact }]
+      routes: [{ path: PublishingAPISection.base_path(@manual_slug, @section_id), type: :exact }]
       })
     enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
     enriched_data = add_base_path_to_child_section_groups(enriched_data)
@@ -26,7 +26,7 @@ class PublishingApiSection
   end
 
   def self.base_path(manual_slug, section_id)
-    File.join(PublishingApiManual.base_path(manual_slug), section_id)
+    File.join(PublishingAPIManual.base_path(manual_slug), section_id)
   end
 
 private
@@ -34,7 +34,7 @@ private
     # child_section_groups isn't required for sections, so might be nil:
     (attributes["details"]["child_section_groups"] || []).each do |section_group|
       section_group["child_sections"].each do |section|
-        section['base_path'] = PublishingApiSection.base_path(@manual_slug, section['section_id'])
+        section['base_path'] = PublishingAPISection.base_path(@manual_slug, section['section_id'])
       end
     end
     attributes
@@ -43,14 +43,14 @@ private
   def add_base_path_to_breadcrumbs(attributes)
     # breadcrumbs isn't required, so might be nil:
     (attributes["details"]["breadcrumbs"] || []).each do |section|
-      section['base_path'] = PublishingApiSection.base_path(@manual_slug, section['section_id'])
+      section['base_path'] = PublishingAPISection.base_path(@manual_slug, section['section_id'])
     end
     attributes
   end
 
   def add_base_path_to_manual(attributes)
     attributes["details"]["manual"].delete("slug")
-    attributes["details"]["manual"]["base_path"] = PublishingApiManual.base_path(@manual_slug)
+    attributes["details"]["manual"]["base_path"] = PublishingAPIManual.base_path(@manual_slug)
     attributes
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -15,12 +15,12 @@ class Section
   end
 
   def publishing_api_section
-    PublishingApiSection.new(self)
+    PublishingAPISection.new(self)
   end
 
   def save!
     api = GdsApi::PublishingApi.new(Plek.current.find('publishing-api'))
-    api.put_content_item(PublishingApiSection.base_path(@manual_slug, @section_id),
+    api.put_content_item(PublishingAPISection.base_path(@manual_slug, @section_id),
                          publishing_api_section.to_h)
   end
 

--- a/config/initializers/acronym.rb
+++ b/config/initializers/acronym.rb
@@ -1,3 +1,4 @@
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'HTML'
+  inflect.acronym 'API'
 end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-describe PublishingApiManual do
+describe PublishingAPIManual do
   describe 'base_path' do
     it 'returns the GOV.UK path for the manual' do
-      base_path = PublishingApiManual.base_path('a-manual')
+      base_path = PublishingAPIManual.base_path('a-manual')
       expect(base_path).to eql('/guidance/a-manual')
     end
   end

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-describe PublishingApiSection do
+describe PublishingAPISection do
   describe 'base_path' do
     it 'returns the GOV.UK path for the section' do
-      base_path = PublishingApiSection.base_path('a-manual', 'a-section-id')
+      base_path = PublishingAPISection.base_path('a-manual', 'a-section-id')
       expect(base_path).to eql('/guidance/a-manual/a-section-id')
     end
   end


### PR DESCRIPTION
- This requires changing everywhere we reference
  `PublishingApi[Manual|Section]` to be `PublishingAPI[Manual|Section]`.
