### PR TITLE
Capitalise acronyms in the app name

### DIFF
--- a/app/models/manual.rb
+++ b/app/models/manual.rb
@@ -17,7 +17,7 @@ class Manual
   end
 
   def save!
-    HmrcManualsApi.publishing_api.put_content_item(
+    HMRCManualsAPI.publishing_api.put_content_item(
       PublishingAPIManual.base_path(@slug),
       publishing_api_manual.to_h
     )

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -18,7 +18,7 @@ class Section
   end
 
   def save!
-    HmrcManualsApi.publishing_api.put_content_item(
+    HMRCManualsAPI.publishing_api.put_content_item(
       PublishingAPISection.base_path(@manual_slug, @section_id),
       publishing_api_section.to_h
     )

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ require "action_view/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module HmrcManualsApi
+module HMRCManualsAPI
   mattr_accessor :publishing_api
 
   class Application < Rails::Application

--- a/config/initializers/acronym.rb
+++ b/config/initializers/acronym.rb
@@ -1,4 +1,5 @@
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'HTML'
   inflect.acronym 'API'
+  inflect.acronym 'HMRC'
 end

--- a/config/initializers/publishing_api.rb
+++ b/config/initializers/publishing_api.rb
@@ -1,3 +1,3 @@
 require 'gds_api/publishing_api'
 
-HmrcManualsApi.publishing_api = GdsApi::PublishingApi.new(Plek.current.find('publishing-api'))
+HMRCManualsAPI.publishing_api = GdsApi::PublishingApi.new(Plek.current.find('publishing-api'))

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -16,4 +16,4 @@
 # Using secret_token for rails3 compatibility. Change to secret_key_base
 # to avoid deprecation warning.
 # Can be safely removed in a rails3 api-only application.
-HmrcManualsApi::Application.config.secret_token = '24333fe7d21a3ee6ea95ef3f2797242c6c846058cdef38a030c4c73672f34456457c62cbe98484293c18a2c7fdb912b5ca3c336c636c66e42df8db8e3d04dd82'
+HMRCManualsAPI::Application.config.secret_token = '24333fe7d21a3ee6ea95ef3f2797242c6c846058cdef38a030c4c73672f34456457c62cbe98484293c18a2c7fdb912b5ca3c336c636c66e42df8db8e3d04dd82'


### PR DESCRIPTION
As per styleguide:
https://github.com/alphagov/styleguides/blob/master/ruby.md#naming
