### PR TITLE
Remove manual slug from Section schema

### DIFF
--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -64,8 +64,9 @@ private
   end
 
   def add_base_path_to_manual(attributes)
-    attributes["details"]["manual"].delete("slug")
-    attributes["details"]["manual"]["base_path"] = PublishingAPIManual.base_path(@manual_slug)
+    attributes["details"]["manual"] = {
+      "base_path" => PublishingAPIManual.base_path(@manual_slug)
+    }
     attributes
   end
 

--- a/json_examples/requests/employment-income-manual/EIM11200.json
+++ b/json_examples/requests/employment-income-manual/EIM11200.json
@@ -6,9 +6,6 @@
   "details": {
     "body": "Incentive awards are a way of rewarding employees and others\nwith cash, goods or holidays rather than increases in pay. Schemes\ncan vary from national promotions to a prize raffle held by a small\nfirm. Rewards of goods or holidays will usually involve the use of\na voucher.\n[EIM16040](/guidance/employment-income-manual/EIM16000#EIM16040) explains the meaning of\n'voucher' for tax purposes.\n\nAwards may be linked to sales performance, good timekeeping,\nsafety or production records, or may involve participation in a\nlottery or prize draw. Schemes may be intended to benefit employees\nor the self-employed, or both.\n\nAwards may be made by the employee's direct employer or by a\nthird party with an interest in the performance of the employee.\nFor example, a car manufacturer is more likely to give an incentive\naward to a person employed by a dealership than the direct\nemployer.\n\nSometimes employers or third parties may buy ready-made\nincentive schemes from a promoter of such schemes, instead of\ndevising their own arrangements. Where this is done, the promoter\nwill generally be responsible for organising the incentive scheme\nand providing the awards to the employees, but will have no\nresponsibility for any tax due on the awards. See\n[EIM11220](/guidance/employment-income-manual/EIM11200#EIM11220) about promoters and tax on\nawards.\n\nFurther guidance is set out at the references listed\nbelow:\n\n",
     "section_id": "EIM11200",
-    "manual": {
-      "slug": "employment-income-manual"
-    },
     "breadcrumbs": [],
     "child_section_groups": [
       {

--- a/json_examples/requests/employment-income-manual/EIM11800.json
+++ b/json_examples/requests/employment-income-manual/EIM11800.json
@@ -8,9 +8,6 @@
   "details": {
     "body": "Optional",
     "section_id": "EIM11800",
-    "manual": {
-      "slug": "employment-income-manual"
-    },
     "breadcrumbs": [],
     "child_section_groups": [
       {

--- a/json_examples/requests/employment-income-manual/EIM25525.json
+++ b/json_examples/requests/employment-income-manual/EIM25525.json
@@ -8,9 +8,6 @@
   "details": {
     "body": "The car fuel benefit charge is not related to the actual cost of providing the fuel.\n\nIf any fuel is provided for any purpose, the statutory car fuel benefit charge is incurred (see [EIM25510](/guidance/employment-income-manual/EIM25500#EIM25510)). The charge is not reduced at all unless the employee makes good the cost of all the fuel provided for private use. In particular, it is not reduced pound for pound to the extent that the employee makes good the fuel provided (see [EIM25650](/guidance/employment-income-manual/EIM25500#EIM25650)).\n\nOnly if the employee makes good the cost of all the fuel provided for private use is the car fuel benefit reduced to nil ([EIM25555](/guidance/employment-income-manual/EIM25500#EIM25555)).\n\n### Years prior to 2003/04\n\nThe fuel benefit charge had a different basis in these years. ",
     "section_id": "EIM25525",
-    "manual": {
-      "slug": "employment-income-manual"
-    },
     // breadcrumbs never include the manual, or this section. They are made up
     // of the sections in between, from left to right.
     "breadcrumbs": [

--- a/public/section-schema.json
+++ b/public/section-schema.json
@@ -30,8 +30,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "section_id",
-        "manual"
+        "section_id"
       ],
       "properties": {
         "body": {
@@ -39,18 +38,6 @@
         },
         "section_id": {
           "type": "string"
-        },
-        "manual": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "slug"
-          ],
-          "properties": {
-            "slug": {
-              "type": "string"
-            }
-          }
         },
         "breadcrumbs": {
           "type": "array",

--- a/spec/support/test_data_helpers.rb
+++ b/spec/support/test_data_helpers.rb
@@ -43,9 +43,6 @@ module TestDataHelpers
       update_type: 'major',
       details: {
         section_id: "12345",
-        manual: {
-          slug: 'employment-income-manual',
-        }
       }
     }.merge(options).deep_stringify_keys
   end
@@ -59,9 +56,6 @@ module TestDataHelpers
       details: {
         body: 'I need **somebody** to love',
         section_id: '12345',
-        manual: {
-          slug: 'employment-income-manual',
-        },
         breadcrumbs: [
           {
             section_id: '1234'


### PR DESCRIPTION
This information is already included in the URL they PUTed to, so it seems
unnecessary to require it. We still need to send it to Publishing API/Content
Store so that a section document knows which manual it is a part of, without
having to know about the structure of its base_path.
