### PR TITLE
Validate the format of Section IDs in JSON

### DIFF
--- a/public/manual-schema.json
+++ b/public/manual-schema.json
@@ -58,7 +58,8 @@
                   ],
                   "properties": {
                     "section_id": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9-]+$"
                     },
                     "title": {
                       "type": "string"

--- a/public/section-schema.json
+++ b/public/section-schema.json
@@ -37,7 +37,8 @@
           "type": "string"
         },
         "section_id": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9-]+$"
         },
         "breadcrumbs": {
           "type": "array",
@@ -49,7 +50,8 @@
             ],
             "properties": {
               "section_id": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-]+$"
               }
             }
           }
@@ -77,7 +79,8 @@
                   ],
                   "properties": {
                     "section_id": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9-]+$"
                     },
                     "title": {
                       "type": "string"

--- a/spec/schema/manual_schema_spec.rb
+++ b/spec/schema/manual_schema_spec.rb
@@ -21,4 +21,15 @@ describe 'manual schema' do
       expect(errors).to eql([])
     end
   end
+
+  describe 'validating section IDs in child_section_groups' do
+    let(:json_path) { '#/details/child_section_groups/0/child_sections/0/section_id' }
+    let(:manual) { maximal_manual }
+    let(:errors) do
+      manual["details"]["child_section_groups"][0]["child_sections"][0]["section_id"] = value
+      get_validation_errors(MANUAL_SCHEMA, manual)
+    end
+
+    it_behaves_like "it validates as a section ID"
+  end
 end

--- a/spec/schema/section_schema_spec.rb
+++ b/spec/schema/section_schema_spec.rb
@@ -21,4 +21,37 @@ describe 'section schema' do
       expect(errors).to eql([])
     end
   end
+
+  describe 'validating section ID in details' do
+    let(:json_path) { '#/details/section_id' }
+    let(:section) { maximal_section }
+    let(:errors) do
+      section["details"]["section_id"] = value
+      get_validation_errors(SECTION_SCHEMA, section)
+    end
+
+    it_behaves_like "it validates as a section ID"
+  end
+
+  describe 'validating section ID in breadcrumbs' do
+    let(:json_path) { '#/details/breadcrumbs/0/section_id' }
+    let(:section) { maximal_section }
+    let(:errors) do
+      section["details"]["breadcrumbs"][0]["section_id"] = value
+      get_validation_errors(SECTION_SCHEMA, section)
+    end
+
+    it_behaves_like "it validates as a section ID"
+  end
+
+  describe 'validating section IDs in child_section_groups' do
+    let(:json_path) { '#/details/child_section_groups/0/child_sections/0/section_id' }
+    let(:section) { maximal_section }
+    let(:errors) do
+      section["details"]["child_section_groups"][0]["child_sections"][0]["section_id"] = value
+      get_validation_errors(SECTION_SCHEMA, section)
+    end
+
+    it_behaves_like "it validates as a section ID"
+  end
 end

--- a/spec/support/shared_examples/schema_validation_failures.rb
+++ b/spec/support/shared_examples/schema_validation_failures.rb
@@ -1,0 +1,26 @@
+RSpec.shared_examples "it rejects the value as not matching" do
+  it 'rejects them' do
+    expect(errors).to_not be_empty
+    expect(errors.first).to include("The property '#{json_path}' value #{value.to_json} did not match the regex")
+  end
+end
+
+RSpec.shared_examples "it validates as a section ID" do
+  context 'slashes' do
+    let(:value) { "No/Slashes\\Allowed"}
+
+    it_behaves_like "it rejects the value as not matching"
+  end
+
+  context 'spaces' do
+    let(:value) { "No Spaces" }
+
+    it_behaves_like "it rejects the value as not matching"
+  end
+
+  context 'underscores' do
+    let(:value) { "No_Underscores" }
+
+    it_behaves_like "it rejects the value as not matching"
+  end
+end


### PR DESCRIPTION
By establishing that Section IDs follow some rules, we can pre-empt errors when
constructing the data we send to Publishing API.
