### PR TITLE
Error with a 415 code if the Content-Type is not application/json

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ private
 
   def check_content_type_header
     if request.headers['Content-Type'] != 'application/json'
-      render json: { status: 'error', errors: 'Invalid headers' }, status: 415
+      render json: { status: 'error', errors: 'Invalid Content-Type header' }, status: 415
     end
   end
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -11,7 +11,7 @@ class ManualsController < ApplicationController
                     location: manual.govuk_url }
       end
     rescue ActionController::UnknownFormat
-      render json: { status: "error", errors: "Invalid headers" }, status: 415
+      render json: { status: "error", errors: "Invalid Accept header" }, status: 406
     rescue ValidationError
       render json: { status: "error", errors: manual.errors.full_messages }, status: 422
     end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -12,7 +12,7 @@ class SectionsController < ApplicationController
                     location: section.govuk_url }
       end
     rescue ActionController::UnknownFormat
-      render json: { status: "error", errors: "Invalid headers" }, status: 415
+      render json: { status: "error", errors: "Invalid Accept header" }, status: 406
     rescue ValidationError
       render json: { status: "error", errors: section.errors.full_messages }, status: 422
     end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -16,12 +16,22 @@ describe 'manual sections resource' do
     expect(response.body).to include("https://www.gov.uk/guidance/employment-income-manual/12345")
   end
 
-  it 'errors if the Accept header and/or the Content-Type header is/are not application/json' do
+  it 'errors if the Accept header is not application/json' do
     stub_default_publishing_api_put
 
-    put '/hmrc-manuals/employment-income-manual/', maximal_section.to_json,
-        headers = {'CONTENT_TYPE' => 'text/plain',
+    put '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section.to_json,
+        headers = {'CONTENT_TYPE' => 'application/json',
                    'HTTP_ACCEPT'  => 'text/plain',
+                   'HTTP_AUTHORIZATION' => 'Bearer 12345'}
+    expect(response.status).to eq(406)
+  end
+
+  it 'errors if the Content-Type header is not application/json' do
+    stub_default_publishing_api_put
+
+    put '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section.to_json,
+        headers = {'CONTENT_TYPE' => 'text/plain',
+                   'HTTP_ACCEPT'  => 'application/json',
                    'HTTP_AUTHORIZATION' => 'Bearer 12345'}
     expect(response.status).to eq(415)
   end

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -30,15 +30,24 @@ describe 'manuals resource' do
     expect(response.status).to eq(422)
     expect(json_response['errors'].first).to eq("Slug should match the pattern: (?-mix:\\A[a-z\\d][a-z\\d-]*[a-z\\d]\\z)")
   end
-  
-  it 'errors if the Accept header and/or the Content-Type header is/are not application/json' do
+
+  it 'errors if the Accept header is not application/json' do
+    stub_default_publishing_api_put
+
+    put '/hmrc-manuals/employment-income-manual/', maximal_manual.to_json,
+        headers = {'CONTENT_TYPE' => 'application/json',
+                   'HTTP_ACCEPT'  => 'text/plain',
+                   'HTTP_AUTHORIZATION' => 'Bearer 12345'}
+    expect(response.status).to eq(406)
+  end
+
+  it 'errors if the Content-Type header is not application/json' do
     stub_default_publishing_api_put
 
     put '/hmrc-manuals/employment-income-manual/', maximal_manual.to_json,
         headers = {'CONTENT_TYPE' => 'text/plain',
-                   'HTTP_ACCEPT'  => 'text/plain',
+                   'HTTP_ACCEPT'  => 'application/json',
                    'HTTP_AUTHORIZATION' => 'Bearer 12345'}
-
     expect(response.status).to eq(415)
   end
 end


### PR DESCRIPTION
- This uses a `before_filter` in ApplicationController to check
  Content-Type, leaving `respond_to` to deal with the Accept header.

(Paired with @benilovj and @rgarner on this, ish.)
