### PR TITLE
Validate that the Section ID and slug match

### DIFF
--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -9,8 +9,9 @@ class PublishingAPISection
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { @section.valid? }
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validate :incoming_section_is_valid
+  validate :section_slug_matches_section_id, if: -> { @section.valid? }
 
-  attr_reader :manual_slug, :section_slug
+  attr_reader :manual_slug, :section_slug, :section_attributes
 
   def initialize(manual_slug, section_slug, section_attributes)
     @manual_slug = manual_slug
@@ -79,6 +80,12 @@ private
   def incoming_section_is_valid
     unless @section.valid?
       @section.errors.full_messages.each {|message| self.errors[:base] << message }
+    end
+  end
+
+  def section_slug_matches_section_id
+    if section_slug.downcase != section_attributes['details']['section_id'].downcase
+      errors[:base] << "Slug in URL and Section ID must match, ignoring case"
     end
   end
 end

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 describe PublishingAPISection do
+  describe 'validations' do
+    describe 'validating that section ID and slug match' do
+      it 'rejects mismatches' do
+        section = PublishingAPISection.new('manual', 'mismatch', valid_section)
+        expect(section).to_not be_valid
+        expect(section.errors[:base].first).to eql('Slug in URL and Section ID must match, ignoring case')
+      end
+    end
+  end
+
   describe 'base_path' do
     it 'returns the GOV.UK path for the section' do
       base_path = PublishingAPISection.base_path('some-manual', 'some-section-id')


### PR DESCRIPTION
This also forces the slug to be the (downcased) section ID, which until now has
just been a convention.
