### PR TITLE
Add organisation to Publishing API payload

### DIFF
--- a/app/models/helpers/publishing_api_helpers.rb
+++ b/app/models/helpers/publishing_api_helpers.rb
@@ -1,0 +1,16 @@
+module Helpers
+  module PublishingAPIHelpers
+    def add_organisations_to_details(attributes)
+      attributes["details"].merge!(
+        "organisations" => [
+          {
+            "title" => "HM Revenue & Customs",
+            "abbreviation" => "HMRC",
+            "web_url" => "https://www.gov.uk/government/organisations/hm-revenue-customs"
+          }
+        ]
+      )
+      attributes
+    end
+  end
+end

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -5,6 +5,7 @@ require 'valid_slug/pattern'
 
 class PublishingAPIManual
   include ActiveModel::Validations
+  include Helpers::PublishingAPIHelpers
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { manual.valid? }
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
@@ -27,7 +28,8 @@ class PublishingAPIManual
       routes: [{ path: PublishingAPIManual.base_path(@slug), type: :exact }]
       })
     enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
-    add_base_path_to_child_section_groups(enriched_data)
+    enriched_data = add_base_path_to_child_section_groups(enriched_data)
+    add_organisations_to_details(enriched_data)
   end
 
   def govuk_url

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -5,6 +5,7 @@ require 'valid_slug/pattern'
 
 class PublishingAPISection
   include ActiveModel::Validations
+  include Helpers::PublishingAPIHelpers
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { @section.valid? }
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
@@ -30,7 +31,8 @@ class PublishingAPISection
     enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
     enriched_data = add_base_path_to_child_section_groups(enriched_data)
     enriched_data = add_base_path_to_breadcrumbs(enriched_data)
-    add_base_path_to_manual(enriched_data)
+    enriched_data = add_base_path_to_manual(enriched_data)
+    add_organisations_to_details(enriched_data)
   end
 
   def govuk_url

--- a/json_examples/send_to_publishing_api/manual.json
+++ b/json_examples/send_to_publishing_api/manual.json
@@ -24,6 +24,13 @@
           }
         ]
       }
+    ],
+    "organisations": [
+      {
+        "title": "HM Revenue & Customs",
+        "abbreviation": "HMRC",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
+      }
     ]
   },
   "publishing_app": "hmrc-manuals-api",

--- a/json_examples/send_to_publishing_api/section.json
+++ b/json_examples/send_to_publishing_api/section.json
@@ -29,6 +29,13 @@
           }
         ]
       }
+    ],
+    "organisations": [
+      {
+        "title": "HM Revenue & Customs",
+        "abbreviation": "HMRC",
+        "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
+      }
     ]
   },
   "publishing_app": "hmrc-manuals-api",

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -20,6 +20,13 @@ module PublishingApiDataHelpers
               }
             ]
           }
+        ],
+        "organisations" => [
+          {
+            "title" => "HM Revenue & Customs",
+            "abbreviation" => "HMRC",
+            "web_url" => "https://www.gov.uk/government/organisations/hm-revenue-customs"
+          }
         ]
       },
       "publishing_app" => "hmrc-manuals-api",
@@ -64,6 +71,13 @@ module PublishingApiDataHelpers
                 "base_path" => "/guidance/employment-income-manual/123456"
               }
             ]
+          }
+        ],
+        "organisations" => [
+          {
+            "title" => "HM Revenue & Customs",
+            "abbreviation" => "HMRC",
+            "web_url" => "https://www.gov.uk/government/organisations/hm-revenue-customs"
           }
         ]
       },


### PR DESCRIPTION
Using an array means that the format (which will be shared with specialist-publisher and then used by manuals-frontend) can accommodate multiple publishing organisations. This isn't currently a requirement, but Specialist Publisher will need it at some point and doing it this way reduces churn in something defined across multiple apps. 

At some point, Publishing API/Content Store will support tagging documents with organisations. At that point, this could be swapped out for that.

/cc @benilovj  @evilstreak
