### PR TITLE
Add change notes to manuals

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -29,7 +29,8 @@ class PublishingAPIManual
       })
     enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
     enriched_data = add_base_path_to_child_section_groups(enriched_data)
-    add_organisations_to_details(enriched_data)
+    enriched_data = add_organisations_to_details(enriched_data)
+    add_base_path_to_change_notes(enriched_data)
   end
 
   def govuk_url
@@ -52,6 +53,13 @@ private
       section_group["child_sections"].each do |section|
         section['base_path'] = PublishingAPISection.base_path(@slug, section['section_id'])
       end
+    end
+    attributes
+  end
+
+  def add_base_path_to_change_notes(attributes)
+    attributes["details"]["change_notes"] && attributes["details"]["change_notes"].each do |change_note_object|
+      change_note_object['base_path'] = PublishingAPISection.base_path(@slug, change_note_object['section_id'])
     end
     attributes
   end

--- a/public/json_examples/requests/employment-income-manual.json
+++ b/public/json_examples/requests/employment-income-manual.json
@@ -36,6 +36,14 @@
           }
         ]
       }
+    ],
+    "change_notes": [
+      {
+        "title": "The title of the section",
+        "section_id": "ADML1100",
+        "change_note": "Change of link “Customs and International” to “ECSM” Sep 2010",
+        "published_at": "2014-03-04T13:58:11+00:00"
+      }
     ]
   },
   "update_type": "major"

--- a/public/json_examples/send_to_publishing_api/manual.json
+++ b/public/json_examples/send_to_publishing_api/manual.json
@@ -31,6 +31,15 @@
         "abbreviation": "HMRC",
         "web_url": "https://www.gov.uk/government/organisations/hm-revenue-customs"
       }
+    ],
+    "change_notes": [
+      {
+        "base_path": "/guidance/employment-income-manual/adml1100",
+        "title": "The title of the section",
+        "section_id": "ADML1100",
+        "change_note": "Change of link “Customs and International” to “ECSM” Sep 2010",
+        "published_at": "2014-03-04T13:58:11+00:00"
+      }
     ]
   },
   "publishing_app": "hmrc-manuals-api",

--- a/public/manual-schema.json
+++ b/public/manual-schema.json
@@ -72,6 +72,36 @@
               }
             }
           }
+        },
+        "change_notes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "title",
+              "section_id",
+              "change_note",
+              "published_at"
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "section_id": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-]+$"
+              },
+              "change_note": {
+                "type": "string"
+              },
+              "published_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "An ISO 8601 datetime, eg 2014-01-23T00:00:00+01:00"
+              }
+            }
+          }
         }
       }
     }

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -27,6 +27,15 @@ module PublishingApiDataHelpers
             "abbreviation" => "HMRC",
             "web_url" => "https://www.gov.uk/government/organisations/hm-revenue-customs"
           }
+        ],
+        "change_notes" => [
+          {
+            "base_path" => "/guidance/employment-income-manual/abc567",
+            "title" => 'Title of a Section that was changed',
+            "section_id" => 'ABC567',
+            "change_note" => 'Description of changes',
+            "published_at" => '2014-01-23T00:00:00+01:00'
+          }
         ]
       },
       "publishing_app" => "hmrc-manuals-api",

--- a/spec/support/test_data_helpers.rb
+++ b/spec/support/test_data_helpers.rb
@@ -31,6 +31,14 @@ module TestDataHelpers
               }
             ]
           }
+        ],
+        change_notes: [
+          {
+            title: 'Title of a Section that was changed',
+            section_id: 'ABC567',
+            change_note: 'Description of changes',
+            published_at: '2014-01-23T00:00:00+01:00'
+          }
         ]
       }
     }.merge(options).deep_stringify_keys


### PR DESCRIPTION
This will power pages equivalent to:
http://www.hmrc.gov.uk/manuals/admlmanual/updates/updateindex.htm

The format is designed to be as close as possible to the Specialist Publisher
change notes format, with the addition of section_id.
