### PR TITLE
Expand list of allowed image hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ The following tag attributes are allowed, by tag:
 * `"time"=>["datetime", "pubdate"]`
 * `"ul"=>["type"]`
 
+### Images
+
 Images are only allowed if on a relative path (ie hosted on `www.gov.uk`) or on
 the GOV.UK assets domain: `assets.digital.cabinet-office.gov.uk`. Markup
 containing images hosted on other domains will be rejected with a 422 error code.
+
+On preview, the allowed image domains are expanded to include the preview
+www.gov.uk domain `www.preview.alphagov.co.uk`) and the preview asset domain
+(`assets-origin.preview.alphagov.co.uk`).

--- a/app/validators/no_dangerous_html_in_text_fields_validator.rb
+++ b/app/validators/no_dangerous_html_in_text_fields_validator.rb
@@ -2,7 +2,15 @@ require 'govspeak/html_validator'
 require 'structured_data'
 
 class NoDangerousHTMLInTextFieldsValidator < ActiveModel::EachValidator
-  ALLOWED_IMAGE_HOSTS = ['www.gov.uk', 'assets.digital.cabinet-office.gov.uk']
+  ALLOWED_IMAGE_HOSTS = [
+    # URLs for the local environment
+    URI.parse(Plek.new.website_root).host, # eg www.preview.alphagov.co.uk
+    URI.parse(Plek.new.asset_root).host,   # eg assets-origin.preview.alphagov.co.uk
+
+    # Hardcode production URLs so that content copied from production is valid
+    'www.gov.uk',
+    'assets.digital.cabinet-office.gov.uk'
+  ]
 
   def validate_each(record, attribute, value)
     freetext_fields_with_paths = StructuredData.new(value).string_fields


### PR DESCRIPTION
We should make sure assets from local environment (dev/preview/production) are
still allowed.
