### PR TITLE
Return the correct govuk_url in development

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -34,7 +34,7 @@ class PublishingAPIManual
   end
 
   def govuk_url
-    Plek.current.website_root + PublishingAPIManual.base_path(@slug)
+    FRONTEND_BASE_URL + PublishingAPIManual.base_path(@slug)
   end
 
   def self.base_path(manual_slug)

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -37,7 +37,7 @@ class PublishingAPISection
   end
 
   def govuk_url
-    Plek.current.website_root + PublishingAPISection.base_path(@manual_slug, @section_slug)
+    FRONTEND_BASE_URL + PublishingAPISection.base_path(@manual_slug, @section_slug)
   end
 
   def self.base_path(manual_slug, section_slug)

--- a/config/initializers/frontend_base_url.rb
+++ b/config/initializers/frontend_base_url.rb
@@ -1,0 +1,5 @@
+FRONTEND_BASE_URL = if Rails.env.development?
+  Plek.new.find('manuals-frontend')
+else
+  Plek.current.website_root
+end


### PR DESCRIPTION
We were returning the "frontend" app's development hostname, but that doesn't host manuals - "manuals-frontend" does. I assume that it works in preview because "router" handles it.
