### PR TITLE
Don't treat descriptions as Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Section IDs are validated to ensure that they can be converted to slugs by simpl
 
 ## Markup
 
-All `description` and `body` attributes in manuals or manual sections may contain
+All `body` attributes in manuals or manual sections may contain
 [markdown](http://daringfireball.net/projects/markdown/syntax). The markdown in those attributes
 is converted to HTML before the document is sent to the Publishing API.
 

--- a/lib/struct_with_rendered_markdown.rb
+++ b/lib/struct_with_rendered_markdown.rb
@@ -1,7 +1,7 @@
 require 'kramdown'
 
 class StructWithRenderedMarkdown
-  ATTRIBUTES_THAT_CAN_CONTAIN_MARKDOWN = [ "body", "description" ]
+  ATTRIBUTES_THAT_CAN_CONTAIN_MARKDOWN = [ "body" ]
 
   def initialize(struct)
     @struct = struct.dup

--- a/spec/models/struct_with_rendered_markdown_spec.rb
+++ b/spec/models/struct_with_rendered_markdown_spec.rb
@@ -12,30 +12,24 @@ describe StructWithRenderedMarkdown do
     )
   end
 
-  it "renders markdown in 'description' fields to HTML" do
-    expect(conversion_of("description" => "# Hello world", "a" => "b")).to eq(
-      "description" => '<h1 id="hello-world">Hello world</h1>' + "\n", "a" => "b"
-    )
-  end
-
   it "recurses through arrays and hashes" do
     recursive_struct = {
       "a" => [
         "b" => {
-          "description" => "**b**"
+          "body" => "**b**"
         },
         "c" => {
-          "description" => "**c**"
+          "body" => "**c**"
         },
       ]
     }
     expect(conversion_of(recursive_struct)).to eq(
       "a" => [
         "b" => {
-          "description" => "<p><strong>b</strong></p>\n"
+          "body" => "<p><strong>b</strong></p>\n"
         },
         "c" => {
-          "description" => "<p><strong>c</strong></p>\n"
+          "body" => "<p><strong>c</strong></p>\n"
         },
       ]
     )

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -4,7 +4,7 @@ module PublishingApiDataHelpers
       "base_path" => "/guidance/employment-income-manual",
       "format" => "hmrc-manual",
       "title" => "Employment Income Manual",
-      "description" => "<p>A manual about incoming employment</p>\n",
+      "description" => "A manual about incoming employment",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",
       "update_type" => "major",
       "details" => {
@@ -15,7 +15,7 @@ module PublishingApiDataHelpers
               {
                 "title" => "About 12345",
                 "section_id" => "12345",
-                "description" => "<p>A short description of the section</p>\n",
+                "description" => "A short description of the section",
                 "base_path" => "/guidance/employment-income-manual/12345"
               }
             ]
@@ -54,7 +54,7 @@ module PublishingApiDataHelpers
       "base_path" => "/guidance/employment-income-manual/12345",
       "format" => "hmrc-manual-section",
       "title" => "A section on a part of employment income",
-      "description" => "<p>Some description</p>\n",
+      "description" => "Some description",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",
       "update_type" => "minor",
       "details" => {
@@ -76,7 +76,7 @@ module PublishingApiDataHelpers
               {
                 "title" => "About 123456",
                 "section_id" => "123456",
-                "description" => "<p>A short description of the section</p>\n",
+                "description" => "A short description of the section",
                 "base_path" => "/guidance/employment-income-manual/123456"
               }
             ]


### PR DESCRIPTION
Specialist Publisher and Manuals Frontend doesn't treat descriptions (aka summaries) as Markdown, so we shouldn't either. If we did, the HTML would be escaped and displayed to the user as content.

/cc @benilovj 
