### PR TITLE
Use HTML entities &rdquo; and &ldquo; for typographical quotes

### DIFF
--- a/public/json_examples/requests/employment-income-manual.json
+++ b/public/json_examples/requests/employment-income-manual.json
@@ -41,7 +41,7 @@
       {
         "title": "The title of the section",
         "section_id": "ADML1100",
-        "change_note": "Change of link “Customs and International” to “ECSM” Sep 2010",
+        "change_note": "Change of link &ldquo;Customs and International&rdquo; to &ldquo;ECSM&rdquo; Sep 2010",
         "published_at": "2014-03-04T13:58:11+00:00"
       }
     ]


### PR DESCRIPTION
- When viewing this JSON file in a browser, the bad encoding was
  rendering them as "â€œ".
- These still won't render in the JSON, but at least now we can tell what they're meant to be...
