### PR TITLE
Register the updates path for the manual

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -25,7 +25,10 @@ class PublishingAPIManual
       format: 'hmrc-manual',
       publishing_app: 'hmrc-manuals-api',
       rendering_app: 'manuals-frontend',
-      routes: [{ path: PublishingAPIManual.base_path(@slug), type: :exact }]
+      routes: [
+        { path: PublishingAPIManual.base_path(@slug), type: :exact },
+        { path: PublishingAPIManual.updates_path(@slug), type: :exact }
+      ]
       })
     enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
     enriched_data = add_base_path_to_child_section_groups(enriched_data)
@@ -40,6 +43,10 @@ class PublishingAPIManual
   def self.base_path(manual_slug)
     # The slug should be lowercase, but let's make sure
     "/guidance/#{manual_slug.downcase}"
+  end
+
+  def self.updates_path(manual_slug)
+    base_path(manual_slug) + '/updates'
   end
 
   def save!

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -44,6 +44,10 @@ module PublishingApiDataHelpers
         {
           "path" => "/guidance/employment-income-manual",
           "type" => "exact"
+        },
+        {
+          "path" => "/guidance/employment-income-manual/updates",
+          "type" => "exact"
         }
       ]
     }.merge(options)


### PR DESCRIPTION
Because we are not registering the updates path for the manual, and the route for the manual itself is "exact", the router doesn't route those requests to this content item, and instead returns a 404.

I wasn't able to prove this is the problem/solution in development, but I'm fairly confident it is correct.
