### PR TITLE
Change "format"s from dashed to underscored

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -22,7 +22,7 @@ class PublishingAPIManual
   def to_h
     enriched_data = @manual_attributes.deep_dup.merge({
       base_path: PublishingAPIManual.base_path(@slug),
-      format: 'hmrc-manual',
+      format: 'hmrc_manual',
       publishing_app: 'hmrc-manuals-api',
       rendering_app: 'manuals-frontend',
       routes: [

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -24,7 +24,7 @@ class PublishingAPISection
   def to_h
     enriched_data = @section_attributes.deep_dup.merge({
       base_path: PublishingAPISection.base_path(@manual_slug, @section_slug),
-      format: 'hmrc-manual-section',
+      format: 'hmrc_manual_section',
       publishing_app: 'hmrc-manuals-api',
       rendering_app: 'manuals-frontend',
       routes: [{ path: PublishingAPISection.base_path(@manual_slug, @section_slug), type: :exact }]

--- a/public/json_examples/send_to_publishing_api/manual.json
+++ b/public/json_examples/send_to_publishing_api/manual.json
@@ -1,6 +1,6 @@
 {
   "base_path": "/guidance/employment-income-manual",
-  "format": "hmrc-manual",
+  "format": "hmrc_manual",
   "title": "Employment Income Manual",
   "description": "A guide to the Income Tax (Earnings and Pensions) Act 2003",
   "public_updated_at": "2014-03-04T13:58:11+00:00",

--- a/public/json_examples/send_to_publishing_api/section.json
+++ b/public/json_examples/send_to_publishing_api/section.json
@@ -1,6 +1,6 @@
 {
   "base_path": "/guidance/employment-income-manual/eim00100",
-  "format": "hmrc-manual-section",
+  "format": "hmrc_manual_section",
   "title": "About this manual",
   "description": null, // or string
   "public_updated_at": "2014-03-04T13:58:11+00:00",

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -2,7 +2,7 @@ module PublishingApiDataHelpers
   def maximal_manual_for_publishing_api(options = {})
     {
       "base_path" => "/guidance/employment-income-manual",
-      "format" => "hmrc-manual",
+      "format" => "hmrc_manual",
       "title" => "Employment Income Manual",
       "description" => "A manual about incoming employment",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",
@@ -56,7 +56,7 @@ module PublishingApiDataHelpers
   def maximal_section_for_publishing_api(options = {})
     {
       "base_path" => "/guidance/employment-income-manual/12345",
-      "format" => "hmrc-manual-section",
+      "format" => "hmrc_manual_section",
       "title" => "A section on a part of employment income",
       "description" => "Some description",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",


### PR DESCRIPTION
Rummager doesn't seem to accept dashed document type values. It would be nice
to have a consistent value for the document type in Rummager and the format
field in both Rummager and Publishing API/Content Store.

Dashes also makes us consistent with everything apart from non-HMRC manuals in Content Store.

I don't believe anything depends on the value of format and there are no live
HMRC manuals yet so there isn't a migration issue.

Non-HMRC manuals, which are managed by Specialist Publisher, currently have
dashed format names and there is at least one live manual. However, they are
not in GOV.UK search at the moment. I suspect that there may be trouble adding
them because they contain dashes.

The context for this is that I want to this app to push HMRC manuals into the search index.
