### PR TITLE
Better section titles in search results

### DIFF
--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -8,19 +8,27 @@ class RummagerSection < RummagerBase
     strip_leading_slash(@publishing_api_section['base_path'])
   end
 
+  def section_id
+    @publishing_api_section['details']['section_id']
+  end
+
+  def title
+    "HMRC Manuals: #{section_id} - #{@publishing_api_section['title']}"
+  end
+
   def body_without_html
     Govspeak::Document.new(@publishing_api_section['details']['body']).to_text
   end
 
   def to_h
     {
-      'title'                   => @publishing_api_section['title'],
+      'title'                   => title,
       'description'             => @publishing_api_section['description'],
       'link'                    => id,
       'indexable_content'       => body_without_html,
       'organisations'           => [GOVUK_HMRC_SLUG],
       'last_update'             => @publishing_api_section['public_updated_at'],
-      'hmrc_manual_section_id'  => @publishing_api_section['details']['section_id'],
+      'hmrc_manual_section_id'  => section_id,
       'manual'                  => strip_leading_slash(@publishing_api_section['details']['manual']['base_path']),
     }
   end

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -12,7 +12,7 @@ module RummagerHelpers
 
   def maximal_section_for_rummager
     {
-      'title'                  => 'A section on a part of employment income',
+      'title'                  => 'HMRC Manuals: 12345 - A section on a part of employment income',
       'description'            => 'Some description',
       'link'                   => 'guidance/employment-income-manual/12345',
       'indexable_content'      => 'I need somebody to love', # Markdown/HTML has been stripped


### PR DESCRIPTION
At the moment, sections appearing in search results don't identify themselves
very well because they are just the section title itself, which, based on the
existing HMRC manuals on www.hmrc.gov.uk, would be things like "Definition of a
Chapter 2 lease". With this change, you can see that it is an HMRC Manual, and
if you searched by section ID, you see that in the search result to help you
identify it.
