### PR TITLE
Log request body with Logstasher

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -4,5 +4,6 @@ if Object.const_defined?('LogStasher') && LogStasher.enabled
     fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
     # Pass request Id to logging
     fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
+    fields[:request_body] = request.body
   end
 end


### PR DESCRIPTION
This is a temporary measure to help debug markdown rendering issues.
It should log the request body as a separate field in the JSON logs
which go into Kibana.
