### PR TITLE
Include the format in search documents

### DIFF
--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -16,6 +16,7 @@ class RummagerManual < RummagerBase
       'indexable_content' => nil,
       'organisations'     => [GOVUK_HMRC_SLUG],
       'last_update'       => @publishing_api_manual['public_updated_at'],
+      'format'            => PublishingAPIManual::FORMAT,
     }
   end
 end

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -30,6 +30,7 @@ class RummagerSection < RummagerBase
       'last_update'             => @publishing_api_section['public_updated_at'],
       'hmrc_manual_section_id'  => section_id,
       'manual'                  => strip_leading_slash(@publishing_api_section['details']['manual']['base_path']),
+      'format'                  => PublishingAPISection::FORMAT,
     }
   end
 end

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -7,6 +7,7 @@ module RummagerHelpers
       'indexable_content' => nil,
       'organisations'     => ['hm-revenue-customs'],
       'last_update'       => '2014-01-23T00:00:00+01:00',
+      'format'            => 'hmrc_manual',
     }
   end
 
@@ -20,6 +21,7 @@ module RummagerHelpers
       'last_update'            => '2014-01-23T00:00:00+01:00',
       'hmrc_manual_section_id' => '12345',
       'manual'                 => 'hmrc-manuals/employment-income-manual',
+      'format'                 => 'hmrc_manual_section',
     }
   end
 end


### PR DESCRIPTION
We should include the format of the document so that it can be used in the
search index for various things, such as weighting the format up and down.

More specifically/imminently, we want to display the format in search results
to give users context on what the search result is when HMRC Manuals and
sections appear in search results.
