### PR TITLE
Add feature flag for logging request body, disabled by default

### DIFF
--- a/config/initializers/log_request_body_feature_flag.rb
+++ b/config/initializers/log_request_body_feature_flag.rb
@@ -1,0 +1,1 @@
+HMRCManualsAPI::Application.config.log_request_body = false

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,13 +1,18 @@
+require_relative 'log_request_body_feature_flag.rb'
+
 if Object.const_defined?('LogStasher') && LogStasher.enabled
   LogStasher.add_custom_fields do |fields|
     # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
     fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
     # Pass request Id to logging
     fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-    # request.body is a StringIO and may have already been read, so we need to
-    # rewind it to read it again (and again afterward reading it this time):
-    request.body.rewind
-    fields[:request_body] = request.body.read
-    request.body.rewind
+
+    if HMRCManualsAPI::Application.config.log_request_body
+      # request.body is a StringIO and may have already been read, so we need to
+      # rewind it to read it again (and again after reading it this time):
+      request.body.rewind
+      fields[:request_body] = request.body.read
+      request.body.rewind
+    end
   end
 end


### PR DESCRIPTION
We only want to log the request body in Preview, because it could use
up quite a lot of disk space if manuals are published in large volumes.
