### PR TITLE
Stop logging GOVUK_Request-Id - it's never going to get frontend traffic

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -4,8 +4,6 @@ if Object.const_defined?('LogStasher') && LogStasher.enabled
   LogStasher.add_custom_fields do |fields|
     # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
     fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass request Id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
 
     if HMRCManualsAPI::Application.config.log_request_body
       # request.body is a StringIO and may have already been read, so we need to


### PR DESCRIPTION
- This was referenced in the Logstasher section of
  https://github.com/alphagov/wiki/wiki/Setting-up-a-new-app#for-rails-apps
  but it is applicable only to frontend apps, which HAPI isn't.
