### PR TITLE
Change the hmrc-manuals GOV.UK prefix to hmrc-internal-manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ The `<manual-slug>` and `<section_slug>` will be used as part of the GOV.UK URL 
 * `201`: created successfully
   * Both `200`s and `201`s return a `Location` header and a response body containing the GOV.UK URL of the manual:
 
-        Location: https://www.gov.uk/hmrc-manuals/<manual_slug>/<section_slug>
+        Location: https://www.gov.uk/hmrc-internal-manuals/<manual_slug>/<section_slug>
 
         {
-          "govuk_url": "https://www.gov.uk/hmrc-manuals/<manual_slug>/<section_slug>"
+          "govuk_url": "https://www.gov.uk/hmrc-internal-manuals/<manual_slug>/<section_slug>"
         }
 
 * `400`: the request JSON isn't well-formed.

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -50,7 +50,7 @@ class PublishingAPIManual
 
   def self.base_path(manual_slug)
     # The slug should be lowercase, but let's make sure
-    "/hmrc-manuals/#{manual_slug.downcase}"
+    "/hmrc-internal-manuals/#{manual_slug.downcase}"
   end
 
   def updates_path

--- a/public/json_examples/send_to_publishing_api/manual.json
+++ b/public/json_examples/send_to_publishing_api/manual.json
@@ -11,13 +11,13 @@
         "title": null, // or string
         "child_sections": [
           {
-            "base_path": "/hmrc-manuals/employment-income-manual/eim00100",
+            "base_path": "/hmrc-internal-manuals/employment-income-manual/eim00100",
             "title": "About this manual",
             "section_id": "EIM00100", // omitted for normal manuals
             "description": null // or string
           },
           {
-            "base_path": "/hmrc-manuals/employment-income-manual/eim11800",
+            "base_path": "/hmrc-internal-manuals/employment-income-manual/eim11800",
             "title": "PAYE: Special types of payment",
             "section_id": "EIM11800", // omitted for normal manuals
             "description": null // or string
@@ -34,7 +34,7 @@
     ],
     "change_notes": [
       {
-        "base_path": "/hmrc-manuals/employment-income-manual/adml1100",
+        "base_path": "/hmrc-internal-manuals/employment-income-manual/adml1100",
         "title": "The title of the section",
         "section_id": "ADML1100",
         "change_note": "Change of link “Customs and International” to “ECSM” Sep 2010",
@@ -46,7 +46,7 @@
   "rendering_app": "manuals-frontend",
   "routes": [
     {
-      "path": "/hmrc-manuals/employment-income-manual",
+      "path": "/hmrc-internal-manuals/employment-income-manual",
       "type": "exact"
     }
   ]

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -4,12 +4,12 @@ describe PublishingAPIManual do
   describe 'base_path' do
     it 'returns the GOV.UK path for the manual' do
       base_path = PublishingAPIManual.base_path('some-manual')
-      expect(base_path).to eql('/hmrc-manuals/some-manual')
+      expect(base_path).to eql('/hmrc-internal-manuals/some-manual')
     end
 
     it 'ensures that it is lowercase' do
       base_path = PublishingAPIManual.base_path('Some-Manual')
-      expect(base_path).to eql('/hmrc-manuals/some-manual')
+      expect(base_path).to eql('/hmrc-internal-manuals/some-manual')
     end
   end
 

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -14,12 +14,12 @@ describe PublishingAPISection do
   describe 'base_path' do
     it 'returns the GOV.UK path for the section' do
       base_path = PublishingAPISection.base_path('some-manual', 'some-section-id')
-      expect(base_path).to eql('/hmrc-manuals/some-manual/some-section-id')
+      expect(base_path).to eql('/hmrc-internal-manuals/some-manual/some-section-id')
     end
 
     it 'ensures that it is lowercase' do
       base_path = PublishingAPISection.base_path('Some-Manual', 'Some-Section-id')
-      expect(base_path).to eql('/hmrc-manuals/some-manual/some-section-id')
+      expect(base_path).to eql('/hmrc-internal-manuals/some-manual/some-section-id')
     end
   end
 

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -14,10 +14,10 @@ describe 'manual sections resource' do
 
     expect(response.status).to eq(200)
     expect(response.headers['Content-Type']).to include('application/json')
-    assert_publishing_api_put_item('/hmrc-manuals/employment-income-manual/12345', maximal_section_for_publishing_api)
+    assert_publishing_api_put_item('/hmrc-internal-manuals/employment-income-manual/12345', maximal_section_for_publishing_api)
     assert_rummager_posted_item(maximal_section_for_rummager)
-    expect(response.headers['Location']).to include("https://www.gov.uk/hmrc-manuals/employment-income-manual/12345")
-    expect(response.body).to include("https://www.gov.uk/hmrc-manuals/employment-income-manual/12345")
+    expect(response.headers['Location']).to include("https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/12345")
+    expect(response.body).to include("https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/12345")
   end
 
   it 'errors if the Accept header is not application/json' do

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -14,10 +14,10 @@ describe 'manuals resource' do
 
     expect(response.status).to eq(200)
     expect(response.headers['Content-Type']).to include('application/json')
-    assert_publishing_api_put_item('/hmrc-manuals/employment-income-manual', maximal_manual_for_publishing_api)
+    assert_publishing_api_put_item('/hmrc-internal-manuals/employment-income-manual', maximal_manual_for_publishing_api)
     assert_rummager_posted_item(maximal_manual_for_rummager)
-    expect(response.headers['Location']).to include('https://www.gov.uk/hmrc-manuals/employment-income-manual')
-    expect(response.body).to include('https://www.gov.uk/hmrc-manuals/employment-income-manual')
+    expect(response.headers['Location']).to include('https://www.gov.uk/hmrc-internal-manuals/employment-income-manual')
+    expect(response.body).to include('https://www.gov.uk/hmrc-internal-manuals/employment-income-manual')
   end
 
   it 'handles the content store being unavailable' do

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -1,7 +1,7 @@
 module PublishingApiDataHelpers
   def maximal_manual_for_publishing_api(options = {})
     {
-      "base_path" => "/hmrc-manuals/employment-income-manual",
+      "base_path" => "/hmrc-internal-manuals/employment-income-manual",
       "format" => "hmrc_manual",
       "title" => "Employment Income Manual",
       "description" => "A manual about incoming employment",
@@ -16,7 +16,7 @@ module PublishingApiDataHelpers
                 "title" => "About 12345",
                 "section_id" => "12345",
                 "description" => "A short description of the section",
-                "base_path" => "/hmrc-manuals/employment-income-manual/12345"
+                "base_path" => "/hmrc-internal-manuals/employment-income-manual/12345"
               }
             ]
           }
@@ -30,7 +30,7 @@ module PublishingApiDataHelpers
         ],
         "change_notes" => [
           {
-            "base_path" => "/hmrc-manuals/employment-income-manual/abc567",
+            "base_path" => "/hmrc-internal-manuals/employment-income-manual/abc567",
             "title" => 'Title of a Section that was changed',
             "section_id" => 'ABC567',
             "change_note" => 'Description of changes',
@@ -42,11 +42,11 @@ module PublishingApiDataHelpers
       "rendering_app" => "manuals-frontend",
       "routes" => [
         {
-          "path" => "/hmrc-manuals/employment-income-manual",
+          "path" => "/hmrc-internal-manuals/employment-income-manual",
           "type" => "exact"
         },
         {
-          "path" => "/hmrc-manuals/employment-income-manual/updates",
+          "path" => "/hmrc-internal-manuals/employment-income-manual/updates",
           "type" => "exact"
         }
       ]
@@ -55,7 +55,7 @@ module PublishingApiDataHelpers
 
   def maximal_section_for_publishing_api(options = {})
     {
-      "base_path" => "/hmrc-manuals/employment-income-manual/12345",
+      "base_path" => "/hmrc-internal-manuals/employment-income-manual/12345",
       "format" => "hmrc_manual_section",
       "title" => "A section on a part of employment income",
       "description" => "Some description",
@@ -65,12 +65,12 @@ module PublishingApiDataHelpers
         "body" => "<p>I need <strong>somebody</strong> to love</p>\n",
         "section_id" => "12345",
         "manual" => {
-          "base_path" => "/hmrc-manuals/employment-income-manual"
+          "base_path" => "/hmrc-internal-manuals/employment-income-manual"
         },
         "breadcrumbs" => [
           {
             "section_id" => "1234",
-            "base_path" => "/hmrc-manuals/employment-income-manual/1234"
+            "base_path" => "/hmrc-internal-manuals/employment-income-manual/1234"
           }
         ],
         "child_section_groups" => [
@@ -81,7 +81,7 @@ module PublishingApiDataHelpers
                 "title" => "About 123456",
                 "section_id" => "123456",
                 "description" => "A short description of the section",
-                "base_path" => "/hmrc-manuals/employment-income-manual/123456"
+                "base_path" => "/hmrc-internal-manuals/employment-income-manual/123456"
               }
             ]
           }
@@ -98,7 +98,7 @@ module PublishingApiDataHelpers
       "rendering_app" => "manuals-frontend",
       "routes" => [
         {
-          "path" => "/hmrc-manuals/employment-income-manual/12345",
+          "path" => "/hmrc-internal-manuals/employment-income-manual/12345",
           "type" => "exact"
         }
       ]

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -3,7 +3,7 @@ module RummagerHelpers
     {
       'title'             => 'Employment Income Manual',
       'description'       => 'A manual about incoming employment',
-      'link'              => 'hmrc-manuals/employment-income-manual',
+      'link'              => 'hmrc-internal-manuals/employment-income-manual',
       'indexable_content' => nil,
       'organisations'     => ['hm-revenue-customs'],
       'last_update'       => '2014-01-23T00:00:00+01:00',
@@ -15,12 +15,12 @@ module RummagerHelpers
     {
       'title'                  => 'HMRC Manuals: 12345 - A section on a part of employment income',
       'description'            => 'Some description',
-      'link'                   => 'hmrc-manuals/employment-income-manual/12345',
+      'link'                   => 'hmrc-internal-manuals/employment-income-manual/12345',
       'indexable_content'      => 'I need somebody to love', # Markdown/HTML has been stripped
       'organisations'          => ['hm-revenue-customs'],
       'last_update'            => '2014-01-23T00:00:00+01:00',
       'hmrc_manual_section_id' => '12345',
-      'manual'                 => 'hmrc-manuals/employment-income-manual',
+      'manual'                 => 'hmrc-internal-manuals/employment-income-manual',
       'format'                 => 'hmrc_manual_section',
     }
   end


### PR DESCRIPTION
- These manuals aren't normal manuals, they're internal manuals
  published solely because of FoI requests. End users should therefore
  be made aware that they're different (and in a different style, etc.)
  hence this change.
- Things have to change here AND in manuals-frontend[1], 'cause we push to
  the publishing API and that has to realise that the URL has changed.

[1] - https://github.com/alphagov/manuals-frontend/compare/change_hmrc_manuals_prefix
