### PR TITLE
Return the status code from the Publishing API to the client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'plek', '1.8.1'
 if ENV['api_dev']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '15.2.0'
+  gem 'gds-api-adapters', '17.1.0'
 end
 gem 'govspeak', '3.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     erubis (2.7.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (15.2.0)
+    gds-api-adapters (17.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -137,7 +137,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.3.2)
-    rdoc (4.1.2)
+    rdoc (4.2.0)
       json (~> 1.4)
     request_store (1.0.6)
     rest-client (1.6.8)
@@ -208,7 +208,7 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   ci_reporter (= 2.0.0.alpha2)
   ci_reporter_rspec (= 0.0.2)
-  gds-api-adapters (= 15.2.0)
+  gds-api-adapters (= 17.1.0)
   gds-sso (= 9.3.0)
   govspeak (= 3.0.0)
   json-schema (= 2.2.3)

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -63,10 +63,12 @@ class PublishingAPIManual
 
   def save!
     raise ValidationError, "manual is invalid" unless valid?
-    HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
+    publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
     rummager_manual = RummagerManual.new(to_h)
     HMRCManualsAPI.rummager.add_document(FORMAT, rummager_manual.id, rummager_manual.to_h)
+
+    publishing_api_response
   end
 
 private

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -56,10 +56,12 @@ class PublishingAPISection
 
   def save!
     raise ValidationError, "section is invalid" unless valid?
-    HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
+    publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
     rummager_section = RummagerSection.new(to_h)
     HMRCManualsAPI.rummager.add_document(FORMAT, rummager_section.id, rummager_section.to_h)
+
+    publishing_api_response
   end
 
 private

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -65,6 +65,15 @@ describe 'manual sections resource' do
     expect(response.status).to eq(500)
   end
 
+  it 'returns the status code from the Publishing API response, not Rummager' do
+    stub_default_publishing_api_put  # This returns 200
+    stub_any_rummager_post_with_queueing_enabled  # This returns 202, as it does in Production
+
+    put_json '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section
+
+    expect(response.status).to eq(200)
+  end
+
   it 'rejects invalid manual slugs' do
     put_json '/hmrc-manuals/BREAK_THE_RULEZ/sections/some-section', valid_section
 

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -29,6 +29,15 @@ describe 'manuals resource' do
     expect(response.status).to eq(503)
   end
 
+  it 'returns the status code from the Publishing API response, not Rummager' do
+    stub_default_publishing_api_put  # This returns 200
+    stub_any_rummager_post_with_queueing_enabled  # This returns 202, as it does in Production
+
+    put_json '/hmrc-manuals/employment-income-manual', maximal_manual
+
+    expect(response.status).to eq(200)
+  end
+
   it 'rejects invalid manual slugs' do
     put_json '/hmrc-manuals/BREAK_THE_RULEZ', valid_manual
 


### PR DESCRIPTION
In production, Rummager queues search index updates so returns 202
to POST requests to insert or overwrite a document:

https://github.com/alphagov/rummager/blob/cc0e9c95db9098b0dbc3dd12124d1eef5a153ae7/app.rb#L460-L466

We have been returning the status code from Rummager to the client,
which is inconsistent with the documentation in the README. It also
seems inaccurate: the content has been saved to the content-store
already and so can be displayed on GOV.UK, so 200/201 is more appropriate.

This commit switches to returning the Publishing API response status
code to the client. It also bumps the version of gds-api-adapters to
pick up the addition of a test helper which stubs a POST request to
Rummager as if queueing is enabled.
