### PR TITLE
Make section titles in search results less repetitive

### DIFF
--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -13,7 +13,7 @@ class RummagerSection < RummagerBase
   end
 
   def title
-    "HMRC Manuals: #{section_id} - #{@publishing_api_section['title']}"
+    "#{section_id} - #{@publishing_api_section['title']}"
   end
 
   def body_without_html

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -13,7 +13,7 @@ module RummagerHelpers
 
   def maximal_section_for_rummager
     {
-      'title'                  => 'HMRC Manuals: 12345 - A section on a part of employment income',
+      'title'                  => '12345 - A section on a part of employment income',
       'description'            => 'Some description',
       'link'                   => 'hmrc-internal-manuals/employment-income-manual/12345',
       'indexable_content'      => 'I need somebody to love', # Markdown/HTML has been stripped


### PR DESCRIPTION
This was included to provide some context/additional information about the
search result is as the titles of sections are often obscure and sections have
no description.

Now, though, the format name is displayed underneath HMRC manual search
results, so that rationale is no longer there. Instead, having the format name
in the search result title makes the list noisier, especially if there are
multiple HMRC manual results.

This is how they currently look:
![screen shot 2015-01-28 at 17 59 55](https://cloud.githubusercontent.com/assets/93739/5943595/376be8b0-a718-11e4-941a-2fa9164dfa81.png)
