### PR TITLE
Remove base_path from Publishing API request body

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -24,7 +24,6 @@ class PublishingAPIManual
   def to_h
     @_to_h ||= begin
       enriched_data = @manual_attributes.deep_dup.merge({
-        base_path: base_path,
         format: FORMAT,
         publishing_app: 'hmrc-manuals-api',
         rendering_app: 'manuals-frontend',
@@ -65,7 +64,7 @@ class PublishingAPIManual
     raise ValidationError, "manual is invalid" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
-    rummager_manual = RummagerManual.new(to_h)
+    rummager_manual = RummagerManual.new(base_path, to_h)
     HMRCManualsAPI.rummager.add_document(FORMAT, rummager_manual.id, rummager_manual.to_h)
 
     publishing_api_response

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -26,7 +26,6 @@ class PublishingAPISection
   def to_h
     @_to_h ||= begin
       enriched_data = @section_attributes.deep_dup.merge({
-        base_path: PublishingAPISection.base_path(@manual_slug, @section_slug),
         format: FORMAT,
         publishing_app: 'hmrc-manuals-api',
         rendering_app: 'manuals-frontend',
@@ -58,7 +57,7 @@ class PublishingAPISection
     raise ValidationError, "section is invalid" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
-    rummager_section = RummagerSection.new(to_h)
+    rummager_section = RummagerSection.new(base_path, to_h)
     HMRCManualsAPI.rummager.add_document(FORMAT, rummager_section.id, rummager_section.to_h)
 
     publishing_api_response

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -1,11 +1,12 @@
 class RummagerManual < RummagerBase
-  def initialize(publishing_api_manual_hash)
+  def initialize(base_path, publishing_api_manual_hash)
+    @base_path = base_path
     @publishing_api_manual = publishing_api_manual_hash
   end
 
   def id
     # The id and link are the path without the leading slash
-    strip_leading_slash(@publishing_api_manual['base_path'])
+    strip_leading_slash(@base_path)
   end
 
   def to_h

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -1,11 +1,12 @@
 class RummagerSection < RummagerBase
-  def initialize(publishing_api_section_hash)
+  def initialize(base_path, publishing_api_section_hash)
+    @base_path = base_path
     @publishing_api_section = publishing_api_section_hash
   end
 
   def id
     # The id and link are the path without the leading slash
-    strip_leading_slash(@publishing_api_section['base_path'])
+    strip_leading_slash(@base_path)
   end
 
   def section_id

--- a/public/json_examples/send_to_publishing_api/manual.json
+++ b/public/json_examples/send_to_publishing_api/manual.json
@@ -1,5 +1,4 @@
 {
-  "base_path": "/hmrc-manuals/employment-income-manual",
   "format": "hmrc_manual",
   "title": "Employment Income Manual",
   "description": "A guide to the Income Tax (Earnings and Pensions) Act 2003",

--- a/public/json_examples/send_to_publishing_api/section.json
+++ b/public/json_examples/send_to_publishing_api/section.json
@@ -1,5 +1,4 @@
 {
-  "base_path": "/hmrc-manuals/employment-income-manual/eim00100",
   "format": "hmrc_manual_section",
   "title": "About this manual",
   "description": null, // or string

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -1,7 +1,6 @@
 module PublishingApiDataHelpers
   def maximal_manual_for_publishing_api(options = {})
     {
-      "base_path" => "/hmrc-internal-manuals/employment-income-manual",
       "format" => "hmrc_manual",
       "title" => "Employment Income Manual",
       "description" => "A manual about incoming employment",
@@ -55,7 +54,6 @@ module PublishingApiDataHelpers
 
   def maximal_section_for_publishing_api(options = {})
     {
-      "base_path" => "/hmrc-internal-manuals/employment-income-manual/12345",
       "format" => "hmrc_manual_section",
       "title" => "A section on a part of employment income",
       "description" => "Some description",


### PR DESCRIPTION
Publishing API currently ignores this field and is about to start rejecting it.
It uses the version in the request URL instead.

See: https://github.com/alphagov/content-store/pull/104