### PR TITLE
Include leading slashes in the link field of manuals sent to Rummager

### DIFF
--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -5,15 +5,14 @@ class RummagerManual < RummagerBase
   end
 
   def id
-    # The id and link are the path without the leading slash
-    strip_leading_slash(@base_path)
+    @base_path
   end
 
   def to_h
     {
       'title'             => @publishing_api_manual['title'],
       'description'       => @publishing_api_manual['description'],
-      'link'              => id,
+      'link'              => @base_path,
       'indexable_content' => nil,
       'organisations'     => [GOVUK_HMRC_SLUG],
       'last_update'       => @publishing_api_manual['public_updated_at'],

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -5,8 +5,7 @@ class RummagerSection < RummagerBase
   end
 
   def id
-    # The id and link are the path without the leading slash
-    strip_leading_slash(@base_path)
+    @base_path
   end
 
   def section_id
@@ -25,7 +24,7 @@ class RummagerSection < RummagerBase
     {
       'title'                   => title,
       'description'             => @publishing_api_section['description'],
-      'link'                    => id,
+      'link'                    => @base_path,
       'indexable_content'       => body_without_html,
       'organisations'           => [GOVUK_HMRC_SLUG],
       'last_update'             => @publishing_api_section['public_updated_at'],

--- a/lib/tasks/republish_rummager_manuals_leading_slash.rake
+++ b/lib/tasks/republish_rummager_manuals_leading_slash.rake
@@ -1,0 +1,19 @@
+require 'gds_api/rummager'
+
+desc "Republish manuals to Rummager with a leading slash. Delete the old ones."
+task republish_rummager_manuals_leading_slash: :environment do
+  rummager = GdsApi::Rummager.new(Plek.current.find('search'))
+
+  # Get all HMRC Manuals.
+  manuals = rummager.unified_search(filter_format: ["hmrc_manual"])['results']
+  manuals.each do |manual|
+    # Add manuals with correct prepended slashes to _id and link fields.
+    # Withdraw manuals whose IDs or links don't start with slashes.
+    unless manual['_id'].starts_with?('/') && manual['link'].starts_with?('/')
+      manual['link'].prepend('/')
+      rummager.add_document('hmrc_manual', manual['_id'].prepend('/'), manual)
+      rummager.delete_document('hmrc_manual', manual['_id'])
+    end
+  end
+  manuals.each {|m| puts m }
+end

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -3,7 +3,7 @@ module RummagerHelpers
     {
       'title'             => 'Employment Income Manual',
       'description'       => 'A manual about incoming employment',
-      'link'              => 'hmrc-internal-manuals/employment-income-manual',
+      'link'              => '/hmrc-internal-manuals/employment-income-manual',
       'indexable_content' => nil,
       'organisations'     => ['hm-revenue-customs'],
       'last_update'       => '2014-01-23T00:00:00+01:00',
@@ -15,7 +15,7 @@ module RummagerHelpers
     {
       'title'                  => '12345 - A section on a part of employment income',
       'description'            => 'Some description',
-      'link'                   => 'hmrc-internal-manuals/employment-income-manual/12345',
+      'link'                   => '/hmrc-internal-manuals/employment-income-manual/12345',
       'indexable_content'      => 'I need somebody to love', # Markdown/HTML has been stripped
       'organisations'          => ['hm-revenue-customs'],
       'last_update'            => '2014-01-23T00:00:00+01:00',


### PR DESCRIPTION
- The link field to be sent to Rummager should be the full path, but
  currently for manuals it's the slug without the leading slash. This is
  thought to have been copied from Specialist Publisher, and is
  apparently only working by coincidence.
- Trello:
  https://trello.com/c/xhObMTuI/72-all-manuals-are-sent-to-rummager-without-the-leading-slash-on-the-path-in-the-link-field.