### PR TITLE
Add initializer for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,12 @@
+redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_keys
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+  config.error_handlers << lambda do |exception, context|
+     Airbrake.notify(exception, parameters: context)
+   end
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_config
+end


### PR DESCRIPTION
We need to explicitly set the redis config for sidekiq, otherwise it tries to
[connect on localhost](https://errbit.preview.alphagov.co.uk/apps/53b3c7360da115d94c000505/problems/55c33d1865786306e7b20400).

This is copied from [Whitehall's initializer](https://github.com/alphagov/whitehall/blob/master/config/initializers/sidekiq.rb), omitting the JSON logging for
sidekiq.