### PR TITLE
Include leading slashes in several fields sent to Rummager

### DIFF
--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -6,8 +6,7 @@ class RummagerManual < RummagerBase
   end
 
   def id
-    # The id and link are the path without the leading slash
-    strip_leading_slash(@base_path)
+    @base_path
   end
 
   def to_h

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -5,8 +5,7 @@ class RummagerSection < RummagerBase
   end
 
   def id
-    # The id and link are the path without the leading slash
-    strip_leading_slash(@base_path)
+    @base_path
   end
 
   def section_id

--- a/lib/tasks/rummager_republish/fix_leading_slashes.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes.rake
@@ -1,0 +1,93 @@
+require 'gds_api/rummager'
+
+namespace :rummager_republish do
+
+  # Use lambdas because methods in Rake tasks are global, which could
+  # cause problems if anyone else were to write more Rake tasks in this
+  # app.
+  base_path = ->(path) { path.starts_with?('/') ? path : "/#{path}" }
+
+  prepare_manual_for_rummager = ->(manual) {
+    manual_data = {
+      'title'             => manual['title'],
+      'description'       => manual['description'],
+      'public_updated_at' => manual['public_timestamp'],
+    }
+    RummagerManual.new(base_path.call(manual['link']), manual_data)
+  }
+
+  prepare_section_for_rummager = ->(section) {
+    details_hash = {
+      'section_id' => section['hmrc_manual_section_id'],
+      'body'       => section['indexable_content'],
+      'manual'     => { base_path: base_path.call(section['manual']) },
+    }
+
+    section_data = {
+      'title'             => section['title'],
+      'description'       => section['description'],
+      'public_updated_at' => section['public_timestamp'],
+      'details'           => details_hash,
+    }
+    RummagerSection.new(base_path.call(section['link']), section_data)
+  }
+
+  desc 'Republish manuals to Rummager with a leading slash. Delete the old ones.'
+  task manuals_with_leading_slash: :environment do
+    rummager = GdsApi::Rummager.new(Plek.current.find('search'))
+    # As of 2015-08-05, there are 5 HMRC manuals. This is a one-off
+    # script to add leading slashes to manuals, and all new manuals
+    # they publish will have leading slashes by default.
+    count = 10
+
+    search_results = rummager.unified_search(filter_format: ['hmrc_manual'],
+                                             count: count.to_s,
+                                             fields: 'title,description,link,indexable_content,last_update')
+
+    raise 'Error: there are more manuals than you are requesting!' if search_results['total'].to_i > count
+
+    all_manuals = search_results['results']
+    broken_manuals = all_manuals.reject { |manual|
+      manual['_id'].starts_with?('/') && manual['link'].starts_with?('/')
+    }
+
+    broken_manuals.each do |manual|
+      rummager.delete_document('hmrc_manual', manual['_id'])
+
+      rummager_manual = prepare_manual_for_rummager.call(manual)
+
+      rummager_manual.save!
+    end
+    puts "Number of manuals fixed: #{broken_manuals.size}."
+  end
+
+  desc 'Republish manual sections to Rummager with a leading slash. Delete the old ones.'
+  task sections_with_leading_slash: :environment do
+    rummager = GdsApi::Rummager.new(Plek.current.find('search'))
+    # As of 2015-08-05, there are 2339 HMRC manual sections. This is a
+    # one-off script to add leading slashes to manual sections, as all
+    # new manuals they publish will have sections with leading slashes
+    # by default.
+    count = 3000
+
+    search_results = rummager.unified_search(filter_format: ['hmrc_manual_section'],
+                                             count: count.to_s,
+                                             fields: 'title,description,link,indexable_content,last_update,hmrc_manual_section_id,manual')
+
+    raise 'Error: there are more manual sections than you are requesting!' if search_results['total'].to_i > count
+
+    all_sections = search_results['results']
+    broken_sections = all_sections.reject { |section|
+      section['_id'].starts_with?('/') && section['link'].starts_with?('/')
+    }
+
+    broken_sections.each do |section|
+      rummager.delete_document(SECTION_FORMAT, section['_id'])
+
+      rummager_section = prepare_section_for_rummager.call(section)
+      rummager_section.save!
+    end
+
+    puts "Number of sections fixed: #{broken_sections.size}."
+  end
+end

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -3,7 +3,7 @@ module RummagerHelpers
     {
       'title'             => 'Employment Income Manual',
       'description'       => 'A manual about incoming employment',
-      'link'              => 'hmrc-internal-manuals/employment-income-manual',
+      'link'              => '/hmrc-internal-manuals/employment-income-manual',
       'indexable_content' => nil,
       'organisations'     => ['hm-revenue-customs'],
       'last_update'       => '2014-01-23T00:00:00+01:00',
@@ -15,7 +15,7 @@ module RummagerHelpers
     {
       'title'                  => '12345 - A section on a part of employment income',
       'description'            => 'Some description',
-      'link'                   => 'hmrc-internal-manuals/employment-income-manual/12345',
+      'link'                   => '/hmrc-internal-manuals/employment-income-manual/12345',
       'indexable_content'      => 'I need somebody to love', # Markdown/HTML has been stripped
       'organisations'          => ['hm-revenue-customs'],
       'last_update'            => '2014-01-23T00:00:00+01:00',


### PR DESCRIPTION
- Stop stripping the leading slashes from `id`, `link` and (in the case of manual sections) `manual` fields in the data we send to Rummager. See the commit message for more detail.
- Add Rake tasks to fix the existing data.

Trello: https://trello.com/c/xhObMTuI/72-all-manuals-are-sent-to-rummager-without-the-leading-slash-on-the-path-in-the-link-field.

(Paired with @mikejustdoit on this.)