### PR TITLE
Send latest change note to Rummager

### DIFF
--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -11,13 +11,14 @@ class RummagerManual < RummagerBase
 
   def to_h
     {
-      'title'             => @publishing_api_manual['title'],
-      'description'       => @publishing_api_manual['description'],
-      'link'              => id,
-      'indexable_content' => nil,
-      'organisations'     => [GOVUK_HMRC_SLUG],
-      'last_update'       => @publishing_api_manual['public_updated_at'],
-      'format'            => MANUAL_FORMAT,
+      'title'              => @publishing_api_manual['title'],
+      'description'        => @publishing_api_manual['description'],
+      'link'               => id,
+      'indexable_content'  => nil,
+      'organisations'      => [GOVUK_HMRC_SLUG],
+      'last_update'        => @publishing_api_manual['public_updated_at'],
+      'format'             => MANUAL_FORMAT,
+      'latest_change_note' => @publishing_api_manual['details']['change_notes'].first,
     }
   end
 

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -34,6 +34,13 @@ module PublishingApiDataHelpers
             "section_id" => 'ABC567',
             "change_note" => 'Description of changes',
             "published_at" => '2014-01-23T00:00:00+01:00'
+          },
+          {
+            "base_path" => "/hmrc-internal-manuals/employment-income-manual/abc555",
+            "title" => "Title of the previous Section that was changed",
+            "section_id" => "ABC555",
+            "change_note" => "Description of changes",
+            "published_at" => "2013-12-23T00:00:00+01:00"
           }
         ]
       },

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -1,13 +1,20 @@
 module RummagerHelpers
   def maximal_manual_for_rummager
     {
-      'title'             => 'Employment Income Manual',
-      'description'       => 'A manual about incoming employment',
-      'link'              => '/hmrc-internal-manuals/employment-income-manual',
-      'indexable_content' => nil,
-      'organisations'     => ['hm-revenue-customs'],
-      'last_update'       => '2014-01-23T00:00:00+01:00',
-      'format'            => 'hmrc_manual',
+      'title'              => 'Employment Income Manual',
+      'description'        => 'A manual about incoming employment',
+      'link'               => '/hmrc-internal-manuals/employment-income-manual',
+      'indexable_content'  => nil,
+      'organisations'      => ['hm-revenue-customs'],
+      'last_update'        => '2014-01-23T00:00:00+01:00',
+      'format'             => 'hmrc_manual',
+      'latest_change_note' => {
+        "title" => "Title of a Section that was changed",
+        "section_id" => "ABC567",
+        "change_note" => "Description of changes",
+        "published_at" => "2014-01-23T00:00:00+01:00",
+        "base_path" => "/hmrc-internal-manuals/employment-income-manual/abc567"
+      },
     }
   end
 

--- a/spec/support/test_data_helpers.rb
+++ b/spec/support/test_data_helpers.rb
@@ -8,7 +8,8 @@ module TestDataHelpers
       public_updated_at: '2014-01-23T00:00:00+01:00',
       update_type: 'minor',
       details: {
-        child_section_groups: []
+        child_section_groups: [],
+        change_notes: [],
       }
     }.merge(options).deep_stringify_keys
   end
@@ -38,6 +39,12 @@ module TestDataHelpers
             section_id: 'ABC567',
             change_note: 'Description of changes',
             published_at: '2014-01-23T00:00:00+01:00'
+          },
+          {
+            title: 'Title of the previous Section that was changed',
+            section_id: 'ABC555',
+            change_note: 'Description of changes',
+            published_at: '2013-12-23T00:00:00+01:00'
           }
         ]
       }


### PR DESCRIPTION
In order to show change notes on the latest feed for a Topic page we
need to send the latest change note to Rummager. This commit modifies
the `RummagerManual` to send the `latest_change_note` which is part of
the core doctype in Rummager.

Ticket:
https://trello.com/c/kGiiEN7A/68-send-hmrc-manuals-change-notes-to-rummager