### PR TITLE
Rename Manual to Topic taks to Topics

### DIFF
--- a/lib/tasks/manuals_to_topics.rake
+++ b/lib/tasks/manuals_to_topics.rake
@@ -25,4 +25,3 @@ task map_manual_topic_slugs_to_content_ids: :environment do
 
   puts "Written the new file to lib/manuals_to_topics_regenerated.csv."
 end
-


### PR DESCRIPTION
It's references as topics in the readme and it matches the naming scheme
around this feature.