### PR TITLE
DO NOT MERGE Send topics to Publishing API

### DIFF
--- a/config/initializers/manuals_topics_content_ids.rb
+++ b/config/initializers/manuals_topics_content_ids.rb
@@ -1,0 +1,5 @@
+require 'manuals_topics_content_ids_loader'
+
+MANUALS_TOPICS_CONTENT_IDS = ManualsTopicsContentIdsLoader.new(
+  IO.read("#{Rails.root}/lib/manuals_to_topics.csv")
+).load

--- a/lib/manuals_topics_content_ids_loader.rb
+++ b/lib/manuals_topics_content_ids_loader.rb
@@ -1,0 +1,33 @@
+require 'csv'
+
+class ManualsTopicsContentIdsLoader
+  def initialize(csv_data)
+    @csv_data = csv_data
+  end
+
+  def load
+    Hash[
+      csv.map { |row|
+        [
+          manual_slug(row),
+          content_ids(row),
+        ]
+      }
+    ]
+  end
+
+private
+  attr_reader :csv_data
+
+  def csv
+    CSV.parse(csv_data, headers: true)
+  end
+
+  def manual_slug(csv_row)
+    csv_row[0]
+  end
+
+  def content_ids(csv_row)
+    csv_row[2].split(",")
+  end
+end

--- a/spec/lib/manuals_topics_content_ids_loader_spec.rb
+++ b/spec/lib/manuals_topics_content_ids_loader_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'manuals_topics_content_ids_loader'
+
+describe ManualsTopicsContentIdsLoader do
+  let(:loader) { ManualsTopicsContentIdsLoader.new(csv_data) }
+
+  let(:csv_data) {
+    <<-EOS.strip
+manual slug,topic slugs,topic ids
+#{manual_with_one_topic},topics/topic-a,topic-a
+#{manual_with_multiple_topics},"topics/topic-a,topics/topic-b","topic-a,topic-b"
+    EOS
+  }
+
+  let(:manual_with_one_topic) { "manuals/manual-0" }
+  let(:manual_with_multiple_topics) { "manuals/manual-1" }
+
+  describe '#load' do
+    it 'returns a hash' do
+      expect(loader.load).to be_a(Hash)
+    end
+
+    it 'returns the correct number of manuals' do
+      expect(loader.load.size).to eq(2)
+    end
+
+    context 'manual with one topic' do
+      let(:hash) { loader.load }
+      let(:content_ids) { hash[manual_with_one_topic] }
+
+      it 'has 1 topic content_id' do
+        expect(content_ids.size).to eq(1)
+      end
+    end
+
+    context 'manual with multiple topics' do
+      let(:hash) { loader.load }
+      let(:content_ids) { hash[manual_with_multiple_topics] }
+
+      it 'has multiple topic content_ids' do
+        expect(content_ids.size).to be > 1
+      end
+    end
+  end
+end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -13,7 +13,9 @@ describe PublishingAPIManual do
     end
   end
 
-  subject(:publishing_api_manual) { PublishingAPIManual.new("some-slug", attributes) }
+  subject(:publishing_api_manual) { PublishingAPIManual.new(slug, attributes, options) }
+  let(:slug) { 'some-slug' }
+  let(:options) { {} }
 
   describe '#to_h' do
     subject { publishing_api_manual.to_h }
@@ -26,6 +28,22 @@ describe PublishingAPIManual do
 
     context 'maximal_manual' do
       let(:attributes) { maximal_manual }
+
+      it { should be_valid_against_schema('hmrc_manual') }
+    end
+
+    context 'linked_manual' do
+      let(:attributes) { valid_manual }
+      let(:options) {
+        {
+          manuals_topics_content_ids: {
+            slug => [
+              'aaaa1111-1111-1aaa-aaaa-111111111111',
+              'bbbb2222-2222-2bbb-bbbb-222222222222',
+            ]
+          }
+        }
+      }
 
       it { should be_valid_against_schema('hmrc_manual') }
     end


### PR DESCRIPTION
We're working towards linking HMRC Manuals to topics.

These changes make use of recently added manual slug -> topic content_ids data (https://github.com/alphagov/hmrc-manuals-api/pull/90) and include that information in the data we export to the Publishing API.

The commits are pretty small and the details can be found in their comments.

These changes depend on the related schema changes being merged https://github.com/alphagov/govuk-content-schemas/pull/107