### PR TITLE
Naming things

### DIFF
--- a/lib/tasks/rummager_republish/fix_leading_slashes.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes.rake
@@ -11,7 +11,7 @@ namespace :rummager_republish do
     manual_data = {
       'title'             => manual['title'],
       'description'       => manual['description'],
-      'public_updated_at' => manual['public_timestamp'],
+      'public_updated_at' => manual['last_update'],
     }
     RummagerManual.new(base_path.call(manual['link']), manual_data)
   }
@@ -26,7 +26,7 @@ namespace :rummager_republish do
     section_data = {
       'title'             => section['title'],
       'description'       => section['description'],
-      'public_updated_at' => section['public_timestamp'],
+      'public_updated_at' => section['last_update'],
       'details'           => details_hash,
     }
     RummagerSection.new(base_path.call(section['link']), section_data)

--- a/lib/tasks/rummager_republish/fix_leading_slashes.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes.rake
@@ -20,7 +20,7 @@ namespace :rummager_republish do
     details_hash = {
       'section_id' => section['hmrc_manual_section_id'],
       'body'       => section['indexable_content'],
-      'manual'     => { base_path: base_path.call(section['manual']) },
+      'manual'     => { 'base_path' => base_path.call(section['manual']) },
     }
 
     section_data = {


### PR DESCRIPTION
- Use correct name for timestamp field in rummager rake tasks: we're fetching the timestamp as `last_update` from Rummager, so need to get this field out of the returned hash to send it back again.
- Stringify key for manual `base_path` in rummager rake task: `RummagerSection#to_h` looks for this key as a string, not a symbol, so we need to fix this for the path to be preserved by the script rather than being set as nil.