### PR TITLE
Send latest change note as string

### DIFF
--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -18,11 +18,19 @@ class RummagerManual < RummagerBase
       'organisations'      => [GOVUK_HMRC_SLUG],
       'last_update'        => @publishing_api_manual['public_updated_at'],
       'format'             => MANUAL_FORMAT,
-      'latest_change_note' => @publishing_api_manual['details']['change_notes'].first,
+      'latest_change_note' => latest_change_note,
     }
   end
 
   def save!
     SendToRummagerWorker.perform_async(MANUAL_FORMAT, self.id, self.to_h)
+  end
+
+private
+
+  def latest_change_note
+    latest = @publishing_api_manual['details'].fetch('change_notes', []).first
+
+    "#{latest['change_note']} in #{latest['title']}" if latest
   end
 end

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -8,13 +8,7 @@ module RummagerHelpers
       'organisations'      => ['hm-revenue-customs'],
       'last_update'        => '2014-01-23T00:00:00+01:00',
       'format'             => 'hmrc_manual',
-      'latest_change_note' => {
-        "title" => "Title of a Section that was changed",
-        "section_id" => "ABC567",
-        "change_note" => "Description of changes",
-        "published_at" => "2014-01-23T00:00:00+01:00",
-        "base_path" => "/hmrc-internal-manuals/employment-income-manual/abc567"
-      },
+      'latest_change_note' => 'Description of changes in Title of a Section that was changed',
     }
   end
 


### PR DESCRIPTION
With the work completed in 729eff we were incorrectly sending a hash to
Rummager for the latest change note. This commit updates it to send a
string structed like so "Title of section changed - description of
change."