### PR TITLE
Document how to test publishing in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The `<slug>` is used as part of the GOV.UK URL for the document.
 [See an example manual](/public/json_examples/requests/employment-income-manual.json)
 
 
-### JSON Schema
+### JSON Schema
 
 [JSON Schema for manuals](public/manual-schema.json)
 
@@ -149,12 +149,12 @@ On preview, the allowed image domains are expanded to include the preview
 www.gov.uk domain `www.preview.alphagov.co.uk`) and the preview asset domain
 (`assets-origin.preview.alphagov.co.uk`).
 
-# Manual tags
+## Manual tags
 
 Manuals can be tagged to topics on GOV.UK, so that they're easier for
 users to find.
 
-## How tagging works
+### How tagging works
 
 Tags are mapped by their content IDs to manual slugs based on the topics each
 manual refers to. This is done via the hardcoded CSV in

--- a/README.md
+++ b/README.md
@@ -169,3 +169,27 @@ process less manual, for the hopefully rare occurrence that we might change
 content IDs, or HMRC might change a manual's topics. It uses current data from
 the content-register to get the content IDs for topic slugs, and regenerates the
 entire CSV file with a `_regenerated` suffix for easy checking.
+
+## Testing publishing in the GOV.UK development VM
+
+You can use the JSON examples of requests for testing publishing in development,
+for example with cURL from the root directory of the repository:
+
+```
+curl -i -XPUT -H'Authorization: Bearer faketoken' -H'Accept: application/json' \
+  -H'Content-Type: application/json' --data-binary \
+  @public/json_examples/requests/employment-income-manual.json \
+  http://hmrc-manuals-api.dev.gov.uk/hmrc-manuals/test-manual
+```
+
+Or with [HTTPie](https://github.com/jkbrzt/httpie):
+
+```
+http PUT http://hmrc-manuals-api.dev.gov.uk/hmrc-manuals/test-manual \
+  Authorization:'Bearer faketoken' Accept:application/json Content-Type:application/json \
+  < public/json_examples/requests/employment-income-manual.json
+```
+
+In development mode the API doesn't require a valid bearer token; any value is
+accepted. To test publishing to our Preview or Staging environments you would
+need a real token for the right environment.


### PR DESCRIPTION
I've added this at the bottom of the README (rather than with the request
documentation) because most of the file is documentation of the API for HMRC
rather than for GDS developers.

Also change the level of the tagging headings and fix a space character in another heading.