### PR TITLE
Fix leading slash script for change notes

### DIFF
--- a/lib/tasks/rummager_republish/fix_leading_slashes.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes.rake
@@ -12,6 +12,7 @@ namespace :rummager_republish do
       'title'             => manual['title'],
       'description'       => manual['description'],
       'public_updated_at' => manual['last_update'],
+      'details'           => {'change_notes' => []},
     }
     RummagerManual.new(base_path.call(manual['link']), manual_data)
   }


### PR DESCRIPTION
Now that we're sending the latest change note to Rummager, the script to fix
the leading slashes needs to include the details hash in the data passed to
the RummagerManual instance. Since this is a one-time script and will be run
straight after deploying 729effb1add96cfea09255fb558a355b19125daa we won't
lose any data by using an empty array for the change_notes field here.