### PR TITLE
Run sidekiq by default in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,10 @@ gem 'govspeak', '3.0.0'
 
 gem 'sidekiq', '3.4.2'
 
+group :development do
+  gem "foreman", "0.78.0"
+end
+
 group :development, :test do
   gem 'rspec-rails', '3.2.1'
   gem 'rspec-collection_matchers', '1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
     erubis (2.7.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    foreman (0.78.0)
+      thor (~> 0.19.1)
     gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
@@ -229,6 +231,7 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   ci_reporter (= 2.0.0.alpha2)
   ci_reporter_rspec (= 0.0.2)
+  foreman (= 0.78.0)
   gds-api-adapters (= 20.1.1)
   gds-sso (= 9.3.0)
   govspeak (= 3.0.0)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: bundle exec rails s -p 3071
 worker: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Sidekiq is now needed for all publishing via the API, so it's useful to have
it running by default in dev.

By adding the web worker to the Procfile and installing foreman, we can run
foreman from the development Procfile so that bowler will run both the rails
server and a sidekiq worker. This follows the pattern of Specialist Publisher
and email alert API.

Related PR: https://github.gds/gds/development/pull/248