### PR TITLE
Stop stripping leading slashes on the `manual` key of sections

### DIFF
--- a/app/models/rummager_base.rb
+++ b/app/models/rummager_base.rb
@@ -1,7 +1,3 @@
 class RummagerBase
   GOVUK_HMRC_SLUG = 'hm-revenue-customs'
-
-  def strip_leading_slash(path)
-    path.gsub(%r{^/}, '')
-  end
 end

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -29,7 +29,7 @@ class RummagerSection < RummagerBase
       'organisations'           => [GOVUK_HMRC_SLUG],
       'public_timestamp'        => @publishing_api_section['public_updated_at'],
       'hmrc_manual_section_id'  => section_id,
-      'manual'                  => strip_leading_slash(@publishing_api_section['details']['manual']['base_path']),
+      'manual'                  => @publishing_api_section['details']['manual']['base_path'],
       'format'                  => SECTION_FORMAT,
     }
   end

--- a/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
@@ -6,6 +6,7 @@ namespace :rummager_republish do
   # cause problems if anyone else were to write more Rake tasks in this
   # app.
   base_path = ->(path) { path.starts_with?('/') ? path : "/#{path}" }
+  title_without_section_ids = ->(title, section_id) { title.gsub("#{section_id} - ", "") }
 
   prepare_section_for_rummager = ->(section) {
     details_hash = {
@@ -15,7 +16,7 @@ namespace :rummager_republish do
     }
 
     section_data = {
-      'title'             => section['title'],
+      'title'             => title_without_section_ids.call(section['title'],section['hmrc_manual_section_id']),
       'description'       => section['description'],
       'public_updated_at' => section['public_timestamp'],
       'details'           => details_hash,

--- a/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
@@ -1,0 +1,48 @@
+require 'gds_api/rummager'
+
+namespace :rummager_republish do
+
+  # Use lambdas because methods in Rake tasks are global, which could
+  # cause problems if anyone else were to write more Rake tasks in this
+  # app.
+  base_path = ->(path) { path.starts_with?('/') ? path : "/#{path}" }
+
+  prepare_section_for_rummager = ->(section) {
+    details_hash = {
+      'section_id' => section['hmrc_manual_section_id'],
+      'body'       => section['indexable_content'],
+      'manual'     => { 'base_path' => base_path.call(section['manual']) },
+    }
+
+    section_data = {
+      'title'             => section['title'],
+      'description'       => section['description'],
+      'public_updated_at' => section['public_timestamp'],
+      'details'           => details_hash,
+    }
+    RummagerSection.new(base_path.call(section['link']), section_data)
+  }
+
+  desc 'Republish manual sections to Rummager with a leading slash.'
+  task sections_with_leading_slash: :environment do
+    rummager = GdsApi::Rummager.new(Plek.current.find('search'))
+    # As of 2015-09-17, there are 2345 HMRC manual sections.
+    count = 3000
+
+    search_results = rummager.unified_search(filter_format: ['hmrc_manual_section'],
+                                             count: count.to_s,
+                                             fields: 'title,description,link,indexable_content,public_timestamp,hmrc_manual_section_id,manual')
+
+    raise 'Error: there are more manual sections than you are requesting!' if search_results['total'].to_i > count
+
+    all_sections = search_results['results']
+    broken_sections = all_sections.reject { |section| section['manual'].starts_with?('/') }
+
+    broken_sections.each do |section|
+      rummager_section = prepare_section_for_rummager.call(section)
+      rummager_section.save!
+    end
+
+    puts "Number of sections fixed: #{broken_sections.size}."
+  end
+end

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -21,7 +21,7 @@ module RummagerHelpers
       'organisations'          => ['hm-revenue-customs'],
       'public_timestamp'       => '2014-01-23T00:00:00+01:00',
       'hmrc_manual_section_id' => '12345',
-      'manual'                 => 'hmrc-internal-manuals/employment-income-manual',
+      'manual'                 => '/hmrc-internal-manuals/employment-income-manual',
       'format'                 => 'hmrc_manual_section',
     }
   end


### PR DESCRIPTION
- We originally thought in #94 that including the leading slash in the
  `manual` slug data for a manual section would break search within a
  manual so that it wouldn't work at all. Turns out from the quick fix
  Jenny did in alphagov/frontend#874 that this
  breaks search within a manual in a different way. For consistency, and
  the ability to get rid of the temporary workaround, don't prepend
  leading slashes to any path-like fields anymore.
- Fix old sections to have leading slashes on `manual` values in Rummager.
- It was found when testing this Rake task locally that
  `section['title']` is made up of the hardcoded `section_id` and the
  section's title. We were sending the title back to Rummager and
  reprocessing it
  (https://github.com/alphagov/hmrc-manuals-api/blob/master/app/models/rummager_section.rb#L15-L17),
  which prepended yet another `section_id` to the title, leading to
  multiple `section_id`s on the beginning of the title. Fix this, too!

(Paired with Jenny on the latter two commits.)