### PR TITLE
Send topics to Publishing API and Rummager (feature-flagged)

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -36,9 +36,14 @@ class PublishingAPIManual
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_organisations_to_details(enriched_data)
-      enriched_data = add_topic_links(enriched_data)
-      enriched_data = add_topic_tags(enriched_data)
-      add_base_path_to_change_notes(enriched_data)
+      enriched_data = add_base_path_to_change_notes(enriched_data)
+
+      if HMRCManualsAPI::Application.config.publish_topics
+        enriched_data = add_topic_links(enriched_data)
+        enriched_data = add_topic_tags(enriched_data)
+      end
+
+      enriched_data
     end
   end
 

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -36,6 +36,8 @@ class PublishingAPIManual
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_organisations_to_details(enriched_data)
+      enriched_data = add_topic_links(enriched_data)
+      enriched_data = add_topic_tags(enriched_data)
       add_base_path_to_change_notes(enriched_data)
     end
   end
@@ -93,6 +95,24 @@ private
     attributes["details"]["change_notes"] && attributes["details"]["change_notes"].each do |change_note_object|
       change_note_object['base_path'] = PublishingAPISection.base_path(@slug, change_note_object['section_id'])
     end
+    attributes
+  end
+
+  def add_topic_links(attributes)
+    if topic_content_ids.present?
+      attributes['links'] ||= {}
+      attributes['links']['topics'] = topic_content_ids
+    end
+
+    attributes
+  end
+
+  def add_topic_tags(attributes)
+    if topic_slugs.present?
+      attributes['details']['tags'] ||= {}
+      attributes['details']['tags']['topics'] = topic_slugs
+    end
+
     attributes
   end
 

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -21,7 +21,9 @@ class RummagerManual < RummagerBase
       'latest_change_note' => latest_change_note,
     }
 
-    data['specialist_sectors'] = topics unless topics.empty?
+    if HMRCManualsAPI::Application.config.publish_topics
+      data['specialist_sectors'] = topics unless topics.empty?
+    end
 
     data
   end

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -10,7 +10,7 @@ class RummagerManual < RummagerBase
   end
 
   def to_h
-    {
+    data = {
       'title'              => @publishing_api_manual['title'],
       'description'        => @publishing_api_manual['description'],
       'link'               => id,
@@ -20,6 +20,10 @@ class RummagerManual < RummagerBase
       'format'             => MANUAL_FORMAT,
       'latest_change_note' => latest_change_note,
     }
+
+    data['specialist_sectors'] = topics unless topics.empty?
+
+    data
   end
 
   def save!
@@ -27,6 +31,9 @@ class RummagerManual < RummagerBase
   end
 
 private
+  def topics
+    @publishing_api_manual['details'].fetch('tags', {}).fetch('topics', [])
+  end
 
   def latest_change_note
     latest = @publishing_api_manual['details'].fetch('change_notes', []).first

--- a/config/initializers/publish_topics_feature_flag.rb
+++ b/config/initializers/publish_topics_feature_flag.rb
@@ -1,0 +1,5 @@
+if Rails.env.production?
+  HMRCManualsAPI::Application.config.publish_topics = ENV["PUBLISH_TOPICS"].present?
+else
+  HMRCManualsAPI::Application.config.publish_topics = true
+end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -6,25 +6,29 @@ describe 'manual sections resource' do
   include GdsApi::TestHelpers::PublishingApi
   include GdsApi::TestHelpers::Rummager
 
+  let(:maximal_section_endpoint) {
+    "/hmrc-manuals/#{maximal_manual_slug}/sections/#{maximal_section_slug}"
+  }
+
   it 'confirms update of the manual section' do
     stub_default_publishing_api_put
     stub_any_rummager_post
 
-    put_json '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section
+    put_json maximal_section_endpoint, maximal_section
 
     expect(response.status).to eq(200)
     expect(response.headers['Content-Type']).to include('application/json')
-    assert_publishing_api_put_item('/hmrc-internal-manuals/employment-income-manual/12345', maximal_section_for_publishing_api)
+    assert_publishing_api_put_item(maximal_section_base_path, maximal_section_for_publishing_api)
     assert_rummager_posted_item(maximal_section_for_rummager)
-    expect(response.headers['Location']).to include("https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/12345")
-    expect(response.body).to include("https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/12345")
+    expect(response.headers['Location']).to include(maximal_section_url)
+    expect(response.body).to include(maximal_section_url)
   end
 
   it 'errors if the Accept header is not application/json' do
     stub_default_publishing_api_put
     stub_any_rummager_post
 
-    put '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section.to_json,
+    put maximal_section_endpoint, maximal_section.to_json,
         headers = {'CONTENT_TYPE' => 'application/json',
                    'HTTP_ACCEPT'  => 'text/plain',
                    'HTTP_AUTHORIZATION' => 'Bearer 12345'}
@@ -34,33 +38,33 @@ describe 'manual sections resource' do
   it 'errors if the Content-Type header is not application/json' do
     stub_default_publishing_api_put
 
-    put '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section.to_json,
+    put maximal_section_endpoint, maximal_section.to_json,
         headers = {'CONTENT_TYPE' => 'text/plain',
                    'HTTP_ACCEPT'  => 'application/json',
                    'HTTP_AUTHORIZATION' => 'Bearer 12345'}
     expect(response.status).to eq(415)
   end
 
-  it 'handles the content store being unavailable' do
+  it 'handles the Publishing API being unavailable' do
     publishing_api_isnt_available
 
-    put_json '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section
+    put_json maximal_section_endpoint, maximal_section
 
     expect(response.status).to eq(503)
   end
 
-  it 'handles the content store request timing out' do
+  it 'handles the Publishing API request timing out' do
     publishing_api_times_out
 
-    put_json '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section
+    put_json maximal_section_endpoint, maximal_section
 
     expect(response.status).to eq(503)
   end
 
-  it 'handles some other error with the content store' do
+  it 'handles some other error with the Publishing API' do
     publishing_api_validation_error
 
-    put_json '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section
+    put_json maximal_section_endpoint, maximal_section
 
     expect(response.status).to eq(500)
   end
@@ -69,7 +73,7 @@ describe 'manual sections resource' do
     stub_default_publishing_api_put  # This returns 200
     stub_any_rummager_post_with_queueing_enabled  # This returns 202, as it does in Production
 
-    put_json '/hmrc-manuals/employment-income-manual/sections/12345', maximal_section
+    put_json maximal_section_endpoint, maximal_section
 
     expect(response.status).to eq(200)
   end

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -1,31 +1,45 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api'
 require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/content_register'
 
 describe 'manuals resource' do
   include GdsApi::TestHelpers::PublishingApi
   include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::ContentRegister
 
   it 'confirms update of the manual' do
     stub_default_publishing_api_put
     stub_any_rummager_post
+    stub_content_register_entries('topic', maximal_manual_topics)
 
-    put_json '/hmrc-manuals/employment-income-manual', maximal_manual
+    put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
     expect(response.status).to eq(200)
     expect(response.headers['Content-Type']).to include('application/json')
 
-    assert_publishing_api_put_item('/hmrc-internal-manuals/employment-income-manual', maximal_manual_for_publishing_api)
+    assert_publishing_api_put_item(maximal_manual_base_path, maximal_manual_for_publishing_api)
     assert_rummager_posted_item(maximal_manual_for_rummager)
-    expect(response.headers['Location']).to include('https://www.gov.uk/hmrc-internal-manuals/employment-income-manual')
-    expect(response.body).to include('https://www.gov.uk/hmrc-internal-manuals/employment-income-manual')
+    expect(response.headers['Location']).to include(maximal_manual_url)
+    expect(response.body).to include(maximal_manual_url)
   end
 
-  it 'handles the content store being unavailable' do
+  it 'handles Content Register being unavailable' do
+    stub_default_publishing_api_put
+    stub_any_rummager_post
+    content_register_isnt_available
+
+    put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
+
+    expect(response.status).to eq(503)
+  end
+
+  it 'handles the Publishing API being unavailable' do
     publishing_api_isnt_available
     stub_any_rummager_post
+    stub_content_register_entries('topic', maximal_manual_topics)
 
-    put_json '/hmrc-manuals/employment-income-manual', maximal_manual
+    put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
     expect(response.status).to eq(503)
   end
@@ -33,8 +47,9 @@ describe 'manuals resource' do
   it 'returns the status code from the Publishing API response, not Rummager' do
     stub_default_publishing_api_put  # This returns 200
     stub_any_rummager_post_with_queueing_enabled  # This returns 202, as it does in Production
+    stub_content_register_entries('topic', maximal_manual_topics)
 
-    put_json '/hmrc-manuals/employment-income-manual', maximal_manual
+    put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
     expect(response.status).to eq(200)
   end
@@ -49,8 +64,9 @@ describe 'manuals resource' do
   it 'errors if the Accept header is not application/json' do
     stub_default_publishing_api_put
     stub_any_rummager_post
+    stub_content_register_entries('topic', maximal_manual_topics)
 
-    put '/hmrc-manuals/employment-income-manual/', maximal_manual.to_json,
+    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json,
         headers = {'CONTENT_TYPE' => 'application/json',
                    'HTTP_ACCEPT'  => 'text/plain',
                    'HTTP_AUTHORIZATION' => 'Bearer 12345'}
@@ -61,7 +77,7 @@ describe 'manuals resource' do
     stub_default_publishing_api_put
     stub_any_rummager_post
 
-    put '/hmrc-manuals/employment-income-manual/', maximal_manual.to_json,
+    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json,
         headers = {'CONTENT_TYPE' => 'text/plain',
                    'HTTP_ACCEPT'  => 'application/json',
                    'HTTP_AUTHORIZATION' => 'Bearer 12345'}

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -24,6 +24,21 @@ describe 'manuals resource' do
     expect(response.body).to include(maximal_manual_url)
   end
 
+  context 'when topics are configured to not be published' do
+    it 'publishes the manual without topics' do
+      stub_default_publishing_api_put
+      stub_any_rummager_post
+      stub_content_register_entries('topic', maximal_manual_topics)
+      allow(HMRCManualsAPI::Application.config).to receive(:publish_topics).and_return(false)
+
+      put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
+
+      expect(response.status).to eq(200)
+      assert_publishing_api_put_item(maximal_manual_base_path, maximal_manual_without_topics_for_publishing_api)
+      assert_rummager_posted_item(maximal_manual_without_topics_for_rummager)
+    end
+  end
+
   it 'handles Content Register being unavailable' do
     stub_default_publishing_api_put
     stub_any_rummager_post

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -42,7 +42,10 @@ module PublishingApiDataHelpers
             "change_note" => "Description of changes",
             "published_at" => "2013-12-23T00:00:00+01:00"
           }
-        ]
+        ],
+        "tags" => {
+          "topics" => maximal_manual_topic_slugs,
+        },
       },
       "publishing_app" => "hmrc-manuals-api",
       "rendering_app" => "manuals-frontend",
@@ -54,8 +57,11 @@ module PublishingApiDataHelpers
         {
           "path" => "/hmrc-internal-manuals/employment-income-manual/updates",
           "type" => "exact"
-        }
-      ]
+        },
+      ],
+      "links" => {
+        "topics" => maximal_manual_topic_content_ids,
+      },
     }.merge(options)
   end
 

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -65,6 +65,13 @@ module PublishingApiDataHelpers
     }.merge(options)
   end
 
+  def maximal_manual_without_topics_for_publishing_api(options = {})
+    manual = maximal_manual_for_publishing_api.deep_dup
+    manual["details"].delete("tags")
+    manual.delete("links")
+    manual.merge(options)
+  end
+
   def maximal_section_for_publishing_api(options = {})
     {
       "format" => "hmrc_manual_section",

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -13,6 +13,12 @@ module RummagerHelpers
     }
   end
 
+  def maximal_manual_without_topics_for_rummager(options = {})
+    manual = maximal_manual_for_rummager.deep_dup
+    manual.delete("specialist_sectors")
+    manual.merge(options)
+  end
+
   def maximal_section_for_rummager
     {
       'title'                  => '12345 - A section on a part of employment income',

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -9,6 +9,7 @@ module RummagerHelpers
       'public_timestamp'   => '2014-01-23T00:00:00+01:00',
       'format'             => 'hmrc_manual',
       'latest_change_note' => 'Description of changes in Title of a Section that was changed',
+      'specialist_sectors' => maximal_manual_topic_slugs,
     }
   end
 

--- a/spec/support/test_data_helpers.rb
+++ b/spec/support/test_data_helpers.rb
@@ -1,6 +1,54 @@
 require 'active_support'
 
 module TestDataHelpers
+  def maximal_manual_slug
+    'employment-income-manual'
+  end
+
+  def maximal_manual_base_path
+    '/hmrc-internal-manuals/employment-income-manual'
+  end
+
+  def maximal_manual_url
+    'https://www.gov.uk/hmrc-internal-manuals/employment-income-manual'
+  end
+
+  def maximal_section_slug
+    '12345'
+  end
+
+  def maximal_section_base_path
+    '/hmrc-internal-manuals/employment-income-manual/12345'
+  end
+
+  def maximal_section_url
+    'https://www.gov.uk/hmrc-internal-manuals/employment-income-manual/12345'
+  end
+
+  def maximal_manual_topic_content_ids
+    # maximal_manual uses a Real World slug, so we make things easier for
+    # ourselves by using its Real World topic content_ids, too, and building
+    # the testable fake data around that
+    MANUALS_TO_TOPICS[maximal_manual_slug]
+  end
+
+  def maximal_manual_topic_slugs
+    maximal_manual_topics.map { |topic|
+      topic['base_path'].sub('/topic/', '')
+    }
+  end
+
+  def maximal_manual_topics
+    maximal_manual_topic_content_ids.map.with_index { |content_id, i|
+      {
+        'base_path' => "/topic/topic-slug-#{i}",
+        'content_id' => content_id,
+        'format' => 'topic',
+        'title' => "Topic Title #{i}",
+      }
+    }
+  end
+
   def valid_manual(options = {})
     {
       title: 'Employment Income Manual',


### PR DESCRIPTION
- Revert the reversion of the initial merge
- Add a feature flag

No Puppet changes are needed for this to be merged and deployed - publishing of topics is disabled by default in production-like environments if the `PUBLISH_TOPICS` envvar doesn't exist. We'll enable it in Preview only for now.