### PR TITLE
Only publish known slugs

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -10,16 +10,17 @@ class PublishingAPIManual
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { manual.valid? }
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
-  validates :slug, inclusion: { in: MANUALS_TO_TOPICS.keys, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
+  validates :slug, inclusion: { in: :known_manual_slugs, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
   validate :incoming_manual_is_valid
 
-  attr_reader :slug, :manual
+  attr_reader :slug, :manual, :known_manual_slugs
 
   def initialize(slug, manual_attributes, options = {})
     @slug = slug
     @manual_attributes = manual_attributes
     @manual = Manual.new(@manual_attributes)
     @topics = options.fetch(:topics, Topics.new(manual_slug: slug))
+    @known_manual_slugs = options.fetch(:known_manual_slugs, MANUALS_TO_TOPICS.keys)
   end
 
   def to_h

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -10,7 +10,7 @@ class PublishingAPIManual
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { manual.valid? }
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
-  validates :slug, inclusion: { in: :known_manual_slugs, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
+  validates :slug, slug_in_known_manual_slugs: true, if: :only_known_hmrc_manual_slugs?
   validate :incoming_manual_is_valid
 
   attr_reader :slug, :manual, :known_manual_slugs

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -10,7 +10,7 @@ class PublishingAPIManual
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { manual.valid? }
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
-  validates :slug, inclusion: { in: MANUALS_TO_TOPICS.keys, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }
+  validates :slug, inclusion: { in: MANUALS_TO_TOPICS.keys, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
   validate :incoming_manual_is_valid
 
   attr_reader :slug, :manual
@@ -126,5 +126,9 @@ private
     unless @manual.valid?
       @manual.errors.full_messages.each {|message| self.errors[:base] << message }
     end
+  end
+
+  def only_known_hmrc_manual_slugs?
+    !HMRCManualsAPI::Application.config.allow_unknown_hmrc_manual_slugs
   end
 end

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -10,6 +10,7 @@ class PublishingAPIManual
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { manual.valid? }
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+  validates :slug, inclusion: { in: MANUALS_TO_TOPICS.keys, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }
   validate :incoming_manual_is_valid
 
   attr_reader :slug, :manual

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -9,17 +9,18 @@ class PublishingAPISection
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { @section.valid? }
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
-  validates :manual_slug, inclusion: { in: MANUALS_TO_TOPICS.keys, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
+  validates :manual_slug, inclusion: { in: :known_manual_slugs, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
   validate :incoming_section_is_valid
   validate :section_slug_matches_section_id, if: -> { @section.valid? }
 
-  attr_reader :manual_slug, :section_slug, :section_attributes
+  attr_reader :manual_slug, :section_slug, :section_attributes, :known_manual_slugs
 
-  def initialize(manual_slug, section_slug, section_attributes)
+  def initialize(manual_slug, section_slug, section_attributes, options = {})
     @manual_slug = manual_slug
     @section_slug = section_slug
     @section_attributes = section_attributes
     @section = Section.new(section_attributes)
+    @known_manual_slugs = options.fetch(:known_manual_slugs, MANUALS_TO_TOPICS.keys)
   end
 
   def to_h

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -9,6 +9,7 @@ class PublishingAPISection
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { @section.valid? }
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+  validates :manual_slug, inclusion: { in: MANUALS_TO_TOPICS.keys, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
   validate :incoming_section_is_valid
   validate :section_slug_matches_section_id, if: -> { @section.valid? }
 
@@ -98,5 +99,9 @@ private
     if section_slug.downcase != section_attributes['details']['section_id'].downcase
       errors[:base] << "Slug in URL and Section ID must match, ignoring case"
     end
+  end
+
+  def only_known_hmrc_manual_slugs?
+    !HMRCManualsAPI::Application.config.allow_unknown_hmrc_manual_slugs
   end
 end

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -9,7 +9,7 @@ class PublishingAPISection
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { @section.valid? }
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
-  validates :manual_slug, inclusion: { in: :known_manual_slugs, message: "does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }" }, if: :only_known_hmrc_manual_slugs?
+  validates :manual_slug, slug_in_known_manual_slugs: true, if: :only_known_hmrc_manual_slugs?
   validate :incoming_section_is_valid
   validate :section_slug_matches_section_id, if: -> { @section.valid? }
 

--- a/app/validators/slug_in_known_manual_slugs_validator.rb
+++ b/app/validators/slug_in_known_manual_slugs_validator.rb
@@ -1,0 +1,7 @@
+class SlugInKnownManualSlugsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless record.known_manual_slugs.include?(value)
+      record.errors[attribute] << "does not match any of the following valid slugs: #{ record.known_manual_slugs.join(" ") }"
+    end
+  end
+end

--- a/config/initializers/allow_unknown_hmrc_slugs_feature_flag.rb
+++ b/config/initializers/allow_unknown_hmrc_slugs_feature_flag.rb
@@ -1,0 +1,5 @@
+if Rails.env.production?
+  HMRCManualsAPI::Application.config.allow_unknown_hmrc_manual_slugs = ENV["ALLOW_UNKNOWN_HMRC_MANUAL_SLUGS"].present?
+else
+  HMRCManualsAPI::Application.config.allow_unknown_hmrc_manual_slugs = true
+end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -18,8 +18,9 @@ describe PublishingAPIManual do
   }
   let(:slug) { 'some-slug' }
   let(:attributes) { valid_manual }
-  let(:options) { { topics: topics } }
+  let(:options) { { topics: topics, known_manual_slugs: known_manual_slugs } }
   let(:topics) { double(content_ids: [], slugs: []) }
+  let(:known_manual_slugs) { [] }
 
   describe '#to_h' do
     subject { publishing_api_manual.to_h }
@@ -92,13 +93,15 @@ describe PublishingAPIManual do
         allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(false)
       end
 
+      let(:known_manual_slugs) { ['known-manual-slug'] }
+
       context "with a manual slug name not in list of known slugs" do
         let(:slug) { 'non-existent-slug' }
         it { should_not be_valid }
       end
 
       context "with a manual slug name in list of known slugs" do
-        let(:slug) { 'admin-law-manual' }
+        let(:slug) { 'known-manual-slug' }
         it { should be_valid }
       end
     end
@@ -108,13 +111,15 @@ describe PublishingAPIManual do
         allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(true)
       end
 
+      let(:known_manual_slugs) { ['known-manual-slug'] }
+
       context "with a manual slug name not in list of known slugs" do
         let(:slug) { 'non-existent-slug' }
         it { should be_valid }
       end
 
       context "with a manual slug name in list of known slugs" do
-        let(:slug) { 'admin-law-manual' }
+        let(:slug) { 'known-manual-slug' }
         it { should be_valid }
       end
     end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -87,14 +87,36 @@ describe PublishingAPIManual do
       end
     end
 
-    context "with a manual slug name not in list of known slugs" do
-      let(:slug) { 'non-existent-slug' }
-      it { should_not be_valid }
+    context 'when app is configured to only allow known slugs' do
+      before do
+        allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(false)
+      end
+
+      context "with a manual slug name not in list of known slugs" do
+        let(:slug) { 'non-existent-slug' }
+        it { should_not be_valid }
+      end
+
+      context "with a manual slug name in list of known slugs" do
+        let(:slug) { 'admin-law-manual' }
+        it { should be_valid }
+      end
     end
 
-    context "with a manual slug name in list of known slugs" do
-      let(:slug) { 'admin-law-manual' }
-      it { should be_valid }
+    context 'when app is configured to allow unknown slugs' do
+      before do
+        allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(true)
+      end
+
+      context "with a manual slug name not in list of known slugs" do
+        let(:slug) { 'non-existent-slug' }
+        it { should be_valid }
+      end
+
+      context "with a manual slug name in list of known slugs" do
+        let(:slug) { 'admin-law-manual' }
+        it { should be_valid }
+      end
     end
   end
 end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -14,8 +14,10 @@ describe PublishingAPIManual do
   end
 
   subject(:publishing_api_manual) {
-    PublishingAPIManual.new('some-slug', attributes, options)
+    PublishingAPIManual.new(slug, attributes, options)
   }
+  let(:slug) { 'some-slug' }
+  let(:attributes) { valid_manual }
   let(:options) { { topics: topics } }
   let(:topics) { double(content_ids: [], slugs: []) }
 
@@ -23,8 +25,6 @@ describe PublishingAPIManual do
     subject { publishing_api_manual.to_h }
 
     context 'valid_manual' do
-      let(:attributes) { valid_manual }
-
       it { should be_valid_against_schema('hmrc_manual') }
     end
 
@@ -35,7 +35,6 @@ describe PublishingAPIManual do
     end
 
     context 'linked_manual' do
-      let(:attributes) { valid_manual }
       let(:topics) {
         double(
           content_ids: [
@@ -86,6 +85,16 @@ describe PublishingAPIManual do
         expect(subject.errors.full_messages[1]).to match(
           %r{'#/details/child_section_groups\[1\]/title' contains disallowed HTML})
       end
+    end
+
+    context "with a manual slug name not in list of known slugs" do
+      let(:slug) { 'non-existent-slug' }
+      it { should_not be_valid }
+    end
+
+    context "with a manual slug name in list of known slugs" do
+      let(:slug) { 'admin-law-manual' }
+      it { should be_valid }
     end
   end
 end

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -14,10 +14,12 @@ describe PublishingAPISection do
   end
 
   subject(:publishing_api_section) {
-    PublishingAPISection.new(manual_slug, section_slug, attributes)
+    PublishingAPISection.new(manual_slug, section_slug, attributes, options)
   }
   let(:manual_slug) { 'some-slug' }
   let(:section_slug) { 'some_id' } 
+  let(:options) { { known_manual_slugs: known_manual_slugs } }
+  let(:known_manual_slugs) { [] }
 
   describe '#to_h' do
     let(:subject) { publishing_api_section.to_h }
@@ -61,6 +63,7 @@ describe PublishingAPISection do
       let(:attributes) { valid_section }
       #section_slug and section_id have to match to pass `:section_slug_matches_section_id` validation
       let(:section_slug) { valid_section['details']['section_id'] }
+      let(:known_manual_slugs) { ['known-manual-slug'] }
 
       before do
         allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(false)
@@ -72,7 +75,7 @@ describe PublishingAPISection do
       end
 
       context "with a manual slug name in list of known slugs" do
-        let(:manual_slug) { 'admin-law-manual' }
+        let(:manual_slug) { 'known-manual-slug' }
         it { should be_valid }
       end
     end

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -28,6 +28,16 @@ describe "validation" do
       expect(json_response["errors"].first).to match(%r{The property '#/' did not contain a required property of 'title' in schema})
     end
 
+    it "validates for known slug name in production environment" do
+      allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(false)
+
+      put_json '/hmrc-manuals/unknown-slug', valid_manual
+
+      expect(response.status).to eq(422)
+      expect(json_response).to include("status" => "error")
+      expect(json_response["errors"].first).to match("does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }")
+    end
+
     context 'manuals with images' do
       it 'rejects manuals with Markdown images not on assets.digital.cabinet-office.gov.uk' do
         manual = valid_manual

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -28,7 +28,7 @@ describe "validation" do
       expect(json_response["errors"].first).to match(%r{The property '#/' did not contain a required property of 'title' in schema})
     end
 
-    it "validates for known slug name in production environment" do
+    it "validates for known manual slug name in production environment" do
       allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(false)
 
       put_json '/hmrc-manuals/unknown-slug', valid_manual
@@ -83,6 +83,16 @@ describe "validation" do
       expect(response.status).to eq(422)
       expect(json_response).to include("status" => "error")
       expect(json_response["errors"].first).to match(%r{The property '#/' did not contain a required property of 'title' in schema})
+    end
+
+    it "validates for known manual slug name in production environment" do
+      allow(HMRCManualsAPI::Application.config).to receive(:allow_unknown_hmrc_manual_slugs).and_return(false)
+
+      put_json '/hmrc-manuals/imaginary-slug/sections/imaginary-section', valid_section
+
+      expect(response.status).to eq(422)
+      expect(json_response).to include("status" => "error")
+      expect(json_response["errors"].first).to match("does not match any of the following valid slugs: #{ MANUALS_TO_TOPICS.keys.join(" ") }")
     end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/8kOVKy90/89-only-allow-publication-of-hmrc-manuals-with-known-slugs-in-production

Reject publishing unknown manual slugs in production environment via use of feature flag.

Concerns:
- In tests we are relying on the actual data, which makes us uncomfortable. Should we look for a solution that would allow us to stub the list of known manual slugs in the tests?
- We've only tested at unit level, should we add a request spec?