### PR TITLE
Allow HMRC to send content_ids

### DIFF
--- a/public/manual-schema.json
+++ b/public/manual-schema.json
@@ -13,6 +13,10 @@
     "title": {
       "type": "string"
     },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "description": {
       "type": "string"
     },

--- a/public/section-schema.json
+++ b/public/section-schema.json
@@ -12,6 +12,10 @@
     "title": {
       "type": "string"
     },
+    "content_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
     "description": {
       "type": "string"
     },

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -3,6 +3,7 @@ module PublishingApiDataHelpers
     {
       "format" => "hmrc_manual",
       "title" => "Employment Income Manual",
+      "content_id" => "913fd52f-072c-409e-88b2-ea0b7a8b6d9c",
       "description" => "A manual about incoming employment",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",
       "update_type" => "major",
@@ -76,6 +77,7 @@ module PublishingApiDataHelpers
     {
       "format" => "hmrc_manual_section",
       "title" => "A section on a part of employment income",
+      "content_id" => "25e687b8-74da-4892-938d-7de82fa5df27",
       "description" => "Some description",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",
       "update_type" => "minor",

--- a/spec/support/test_data_helpers.rb
+++ b/spec/support/test_data_helpers.rb
@@ -65,6 +65,7 @@ module TestDataHelpers
   def maximal_manual(options = {})
     {
       title: 'Employment Income Manual',
+      content_id: '913fd52f-072c-409e-88b2-ea0b7a8b6d9c',
       description: 'A manual about incoming employment',
       public_updated_at: '2014-01-23T00:00:00+01:00',
       update_type: 'major',
@@ -113,6 +114,7 @@ module TestDataHelpers
   def maximal_section(options = {})
     {
       title: 'A section on a part of employment income',
+      content_id: '25e687b8-74da-4892-938d-7de82fa5df27',
       description: 'Some description',
       public_updated_at: '2014-01-23T00:00:00+01:00',
       update_type: 'minor',


### PR DESCRIPTION
This commit makes it possible for HMRC to send a `content_id` for manuals and sections. We'd like manuals to have content_ids to enable tagging in the new tagging infrastructure.

The tests require a little explanation. By adding a `content_id` to `TestDataHelpers#maximal_manual` we simulate all calls to `PUT /hmrc-manuals-api/:slug` in `requests/manual_spec.rb` include a content_id.

By adding the same `content_id` to `PublishingApiDataHelpers#maximal_manual_for_publishing_api` we then verify that the `content_id` is forwarded to the content-store.

Trello: https://trello.com/c/xfBqOPfJ