### PR TITLE
Cleanup incorrectly published manuals

### DIFF
--- a/app/models/invalid_json_error.rb
+++ b/app/models/invalid_json_error.rb
@@ -1,0 +1,1 @@
+class InvalidJSONError < StandardError; end

--- a/app/models/invalid_path_error.rb
+++ b/app/models/invalid_path_error.rb
@@ -1,0 +1,1 @@
+class InvalidPathError < StandardError; end

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -57,9 +57,18 @@ class PublishingAPIManual
     PublishingAPIManual.base_path(@slug)
   end
 
+  BASE_PATH_SEGMENT = 'hmrc-internal-manuals'
+
   def self.base_path(manual_slug)
     # The slug should be lowercase, but let's make sure
-    "/hmrc-internal-manuals/#{manual_slug.downcase}"
+    "/#{BASE_PATH_SEGMENT}/#{manual_slug.downcase}"
+  end
+
+  def self.extract_slug_from_path(path)
+    raise InvalidPathError if path.blank? || path !~ %r{\A/#{BASE_PATH_SEGMENT}/}
+    slug = path.split('/',4).third
+    raise InvalidPathError if slug.blank?
+    slug
   end
 
   def updates_path

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -53,7 +53,7 @@ class PublishingAPIRemovedManual
   end
 
   def save!
-    raise ValidationError, "manual to remove is invalid" unless valid?
+    raise ValidationError, "manual to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
     HMRCManualsAPI.rummager.delete_document(MANUAL_FORMAT, base_path_for_rummager)

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -1,0 +1,45 @@
+require 'active_model'
+require 'valid_slug/pattern'
+
+class PublishingAPIRemovedManual
+  include ActiveModel::Validations
+
+  validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+
+  attr_reader :slug
+
+  def initialize(slug)
+    @slug = slug
+  end
+
+  def to_h
+    @_to_h ||= {
+      format: 'gone',
+      publishing_app: 'hmrc-manuals-api',
+      update_type: 'major',
+      routes: [
+        { path: base_path, type: :exact },
+        { path: updates_path, type: :exact },
+      ],
+    }
+  end
+
+  def base_path
+    PublishingAPIManual.base_path(@slug)
+  end
+
+  def updates_path
+    PublishingAPIManual.updates_path(@slug)
+  end
+
+  def save!
+    raise ValidationError, "manual to remove is invalid" unless valid?
+    publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
+
+    # rummager_manual = RummagerManual.new(base_path, to_h)
+    # rummager_manual.save!
+
+    publishing_api_response
+  end
+
+end

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -28,6 +28,10 @@ class PublishingAPIRemovedManual
     PublishingAPIManual.base_path(@slug)
   end
 
+  def base_path_for_rummager
+    base_path.sub(/\A\//,'')
+  end
+
   def updates_path
     PublishingAPIManual.updates_path(@slug)
   end
@@ -36,8 +40,7 @@ class PublishingAPIRemovedManual
     raise ValidationError, "manual to remove is invalid" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
-    # rummager_manual = RummagerManual.new(base_path, to_h)
-    # rummager_manual.save!
+    HMRCManualsAPI.rummager.delete_document(MANUAL_FORMAT, base_path_for_rummager)
 
     publishing_api_response
   end

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -12,6 +12,18 @@ class PublishingAPIRemovedManual
     @slug = slug
   end
 
+  def sections
+    sections_from_rummager.map do |section_json|
+      PublishingAPIRemovedSection.from_rummager_result(section_json)
+    end
+  end
+
+  def sections_from_rummager
+    query = RummagerSection.search_query(base_path)
+    HMRCManualsAPI.rummager.unified_search(query).results
+  end
+  private :sections_from_rummager
+
   def to_h
     @_to_h ||= {
       format: 'gone',

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -5,6 +5,10 @@ class PublishingAPIRemovedManual
   include ActiveModel::Validations
 
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+  validates_with InContentStoreValidator,
+    format: MANUAL_FORMAT,
+    content_store: HMRCManualsAPI.content_store,
+    unless: -> { errors[:slug].present? }
 
   attr_reader :slug
 

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -34,12 +34,15 @@ class PublishingAPIRemovedSection
     PublishingAPISection.base_path(@manual_slug, @section_slug)
   end
 
+  def base_path_for_rummager
+    base_path.sub(/\A\//,'')
+  end
+
   def save!
     raise ValidationError, "manual section to remove is invalid" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
-    # rummager_manual = RummagerSection.new(base_path, to_h)
-    # rummager_manual.save!
+    HMRCManualsAPI.rummager.delete_document(SECTION_FORMAT, base_path_for_rummager)
 
     publishing_api_response
   end

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -1,0 +1,41 @@
+require 'active_model'
+require 'valid_slug/pattern'
+
+class PublishingAPIRemovedSection
+  include ActiveModel::Validations
+
+  validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+
+  attr_reader :manual_slug, :section_slug
+
+  def initialize(manual_slug, section_slug)
+    @manual_slug = manual_slug
+    @section_slug = section_slug
+  end
+
+  def to_h
+    @_to_h ||= {
+      format: 'gone',
+      publishing_app: 'hmrc-manuals-api',
+      update_type: 'major',
+      routes: [
+        { path: base_path, type: :exact },
+      ],
+    }
+  end
+
+  def base_path
+    PublishingAPISection.base_path(@manual_slug, @section_slug)
+  end
+
+  def save!
+    raise ValidationError, "manual section to remove is invalid" unless valid?
+    publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
+
+    # rummager_manual = RummagerSection.new(base_path, to_h)
+    # rummager_manual.save!
+
+    publishing_api_response
+  end
+
+end

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -5,6 +5,10 @@ class PublishingAPIRemovedSection
   include ActiveModel::Validations
 
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+  validates_with InContentStoreValidator,
+    format: SECTION_FORMAT,
+    content_store: HMRCManualsAPI.content_store,
+    unless: -> { errors[:manual_slug].present? || errors[:section_slug].present? }
 
   attr_reader :manual_slug, :section_slug
 

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -43,7 +43,7 @@ class PublishingAPIRemovedSection
   end
 
   def save!
-    raise ValidationError, "manual section to remove is invalid" unless valid?
+    raise ValidationError, "manual section to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
     HMRCManualsAPI.rummager.delete_document(SECTION_FORMAT, base_path_for_rummager)

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -8,6 +8,12 @@ class PublishingAPIRemovedSection
 
   attr_reader :manual_slug, :section_slug
 
+  def self.from_rummager_result(rummager_result)
+    raise InvalidJSONError if rummager_result.blank? || rummager_result['link'].blank?
+    slugs = PublishingAPISection.extract_slugs_from_path(rummager_result['link'])
+    new(slugs[:manual], slugs[:section])
+  end
+
   def initialize(manual_slug, section_slug)
     @manual_slug = manual_slug
     @section_slug = section_slug

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -54,6 +54,14 @@ class PublishingAPISection
     File.join(PublishingAPIManual.base_path(manual_slug.downcase), section_slug.downcase)
   end
 
+  def self.extract_slugs_from_path(path)
+    slugs = {}
+    slugs[:manual] = PublishingAPIManual.extract_slug_from_path(path)
+    slugs[:section] = path.split('/', 5).fourth
+    raise InvalidPathError if slugs[:section].blank?
+    slugs
+  end
+
   def save!
     raise ValidationError, "section is invalid" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -37,4 +37,12 @@ class RummagerSection < RummagerBase
   def save!
     SendToRummagerWorker.perform_async(SECTION_FORMAT, self.id, self.to_h)
   end
+
+  def self.search_query(manual_path)
+    {
+      'filter_format' => SECTION_FORMAT,
+      'filter_organisations' => [GOVUK_HMRC_SLUG],
+      'filter_manual' => manual_path
+    }
+  end
 end

--- a/app/validators/in_content_store_validator.rb
+++ b/app/validators/in_content_store_validator.rb
@@ -1,0 +1,38 @@
+class InContentStoreValidator < ActiveModel::Validator
+  attr_reader :format, :content_store
+  def initialize(options = {})
+    super
+    raise "Must provide format and content_store options to the validator" unless (options[:format] && options[:content_store])
+    raise 'Can\'t provide "gone" as a format to the validator' if options[:format] == 'gone'
+    @format = options[:format]
+    @content_store = options[:content_store]
+  end
+
+  def validate(record)
+    content_item = fetch_content_item(record)
+    if content_item.nil?
+      record.errors.add(:base, missing_message(record, content_item) )
+    elsif content_item.format == 'gone'
+      record.errors.add(:base, gone_message(record, content_item))
+    elsif content_item.format != format
+      record.errors.add(:base, wrong_format_message(record, content_item))
+    end
+  end
+
+  private
+  def fetch_content_item(record)
+    content_store.content_item(record.base_path)
+  end
+
+  def missing_message(_record, _content_item)
+    'Is not a manual in the content store'
+  end
+
+  def gone_message(_record, _content_item)
+    'Exists in the content store, but is already "gone"'
+  end
+
+  def wrong_format_message(_record, content_item)
+    %Q{Exists in the content store, but is not a "#{format} (it's a "#{content_item.format}"')"}
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module HMRCManualsAPI
   mattr_accessor :content_register
   mattr_accessor :publishing_api
   mattr_accessor :rummager
+  mattr_accessor :content_store
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/content_store.rb
+++ b/config/initializers/content_store.rb
@@ -1,0 +1,3 @@
+require 'gds_api/content_store'
+
+HMRCManualsAPI.content_store = GdsApi::ContentStore.new(Plek.current.find('content-store'))

--- a/lib/tasks/remove_manuals.rake
+++ b/lib/tasks/remove_manuals.rake
@@ -1,0 +1,30 @@
+desc "Takes a list of slugs of manuals to remove and makes the appropriate requests to content apis to do so"
+task :remove_hmrc_manuals, [] => :environment do |_task, args|
+  def output_error_message(message)
+    puts "ERROR!"
+    print "  "
+    puts message
+  end
+
+  def remove_and_output(manual)
+    response = manual.save!
+    if response.code == 200
+      puts "OK!"
+    else
+      output_error_message(response.raw_response_body)
+    end
+  rescue => e
+    output_error_message(e.message)
+  end
+
+  slugs = args.extras
+  if slugs.empty?
+    puts "Usage: rake remove_hmrc_manuals[slug-to-remove-1,slug-to-remove-2,...,slug-to-remove-n]"
+  else
+    slugs.each do |manual_slug|
+      print "Removing manual '#{manual_slug}': "
+      manual = PublishingAPIRemovedManual.new(manual_slug)
+      remove_and_output(manual)
+    end
+  end
+end

--- a/lib/tasks/remove_manuals.rake
+++ b/lib/tasks/remove_manuals.rake
@@ -25,6 +25,10 @@ task :remove_hmrc_manuals, [] => :environment do |_task, args|
       print "Removing manual '#{manual_slug}': "
       manual = PublishingAPIRemovedManual.new(manual_slug)
       remove_and_output(manual)
+      manual.sections.each do |section|
+        print "  Removing section '#{manual_slug}/#{section.section_slug}'"
+        remove_and_output(section)
+      end
     end
   end
 end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -13,15 +13,38 @@ describe PublishingAPIManual do
     end
   end
 
-  describe '.update_path' do
-    it 'returns the GOV.UK path for the updates to the manual' do
-      update_path = PublishingAPIManual.update_path('some-manual')
-      expect(update_path).to eql('/hmrc-internal-manuals/some-manual/updates')
+  describe '.extract_slug_from_path' do
+    it 'finds the first path segment after the base path segment' do
+      extracted_slug = described_class.extract_slug_from_path('/hmrc-internal-manuals/what-a-slug')
+      expect(extracted_slug).to eq('what-a-slug')
     end
 
-    it 'ensures that it is lowercase' do
-      update_path = PublishingAPIManual.update_path('Some-Manual')
-      expect(update_path).to eql('/hmrc-internal-manuals/some-manual/updates')
+    it 'ignores trailing slashes' do
+      extracted_slug = described_class.extract_slug_from_path('/hmrc-internal-manuals/what-a-slug/')
+      expect(extracted_slug).to eq('what-a-slug')
+    end
+
+    it 'ignores path segments after the first one' do
+      extracted_slug = described_class.extract_slug_from_path('/hmrc-internal-manuals/what-a-slug/section-slug')
+      expect(extracted_slug).to eq('what-a-slug')
+    end
+
+    it 'raises an InvalidPathErrorInvalidPathError exception if the path is blank' do
+      expect {
+        described_class.extract_slug_from_path('')
+      }.to raise_error(InvalidPathError)
+    end
+
+    it 'raises an InvalidPathError exception if the path does not start with the base path segment' do
+      expect {
+        described_class.extract_slug_from_path('/fco-travel-advice/dont-go-back-to-rockville')
+      }.to raise_error(InvalidPathError)
+    end
+
+    it 'raises an InvalidPathError exception if the path does start with the base path segment, but has no 2nd path segment' do
+      expect {
+        described_class.extract_slug_from_path('/hmrc-internal-manuals/')
+      }.to raise_error(InvalidPathError)
     end
   end
 

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -13,6 +13,18 @@ describe PublishingAPIManual do
     end
   end
 
+  describe '.update_path' do
+    it 'returns the GOV.UK path for the updates to the manual' do
+      update_path = PublishingAPIManual.update_path('some-manual')
+      expect(update_path).to eql('/hmrc-internal-manuals/some-manual/updates')
+    end
+
+    it 'ensures that it is lowercase' do
+      update_path = PublishingAPIManual.update_path('Some-Manual')
+      expect(update_path).to eql('/hmrc-internal-manuals/some-manual/updates')
+    end
+  end
+
   subject(:publishing_api_manual) {
     PublishingAPIManual.new(slug, attributes, options)
   }

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api'
-
+require 'gds_api/test_helpers/rummager'
 
 describe PublishingAPIRemovedManual do
   describe 'validations' do
@@ -44,6 +44,7 @@ describe PublishingAPIRemovedManual do
 
   describe '#save!' do
     include GdsApi::TestHelpers::PublishingApi
+    include GdsApi::TestHelpers::Rummager
 
     describe 'for an invalid manual' do
       subject(:removed_manual) { described_class.new('this_is_not_acc3ptABLE!') }
@@ -63,16 +64,21 @@ describe PublishingAPIRemovedManual do
       end
     end
 
-    describe 'for a valid manaul' do
+    describe 'for a valid manual' do
       subject(:removed_manual) { described_class.new('some-slug') }
       let(:publishing_api_base_path) { '/hmrc-internal-manuals/some-slug' }
 
       it 'issues a put_item request to the publishing api to mark the manual as gone' do
         stub_default_publishing_api_put
+        stub_any_rummager_delete
 
         subject.save!
 
         assert_publishing_api_put_item(publishing_api_base_path, gone_manual_for_publishing_api)
+
+        #TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`
+        #      once https://github.com/alphagov/gds-api-adapters/pull/362 has been merged
+        assert_requested(:delete, %r{#{Plek.new.find('search')}/documents#{publishing_api_base_path}})
       end
     end
 

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api'
+
+
+describe PublishingAPIRemovedManual do
+  describe 'validations' do
+    it 'is invalid without a slug' do
+      expect(described_class.new(nil)).not_to be_valid
+    end
+
+    it 'is invalid with a slug that does not match the valid_slug/pattern' do
+      expect(described_class.new("1Som\nSłu9G!")).not_to be_valid
+    end
+  end
+
+  describe '#to_h' do
+    let(:removed_manual) { described_class.new('some-slug') }
+    subject(:removed_manual_as_hash) { removed_manual.to_h }
+
+    it 'is a "gone" format object' do
+      expect(subject[:format]).to eq('gone')
+    end
+
+    it 'is published by the "hmrc-manuals-api" app' do
+      expect(subject[:publishing_app]).to eq('hmrc-manuals-api')
+    end
+
+    it 'is a major update' do
+      expect(subject[:update_type]).to eq('major')
+    end
+
+    it 'has two routes' do
+      expect(subject[:routes].size).to eq(2)
+    end
+
+    it 'includes the base_path of the manual as an exact path in routes' do
+      expect(subject[:routes]).to include({ path: removed_manual.base_path, type: :exact })
+    end
+
+    it 'includes the updates_path of the manual as an exact path in routes' do
+      expect(subject[:routes]).to include({ path: removed_manual.updates_path, type: :exact })
+    end
+  end
+
+  describe '#save!' do
+    include GdsApi::TestHelpers::PublishingApi
+
+    describe 'for an invalid manual' do
+      subject(:removed_manual) { described_class.new('this_is_not_acc3ptABLE!') }
+
+      it 'raises a validation error' do
+        expect {
+          subject.save!
+        }.to raise_error(ValidationError)
+      end
+
+      it 'does not communicate with the publishing api' do
+        publishing_api_stub = stub_default_publishing_api_put
+
+        ignoring(ValidationError) { subject.save! }
+
+        assert_not_requested publishing_api_stub
+      end
+    end
+
+    describe 'for a valid manaul' do
+      subject(:removed_manual) { described_class.new('some-slug') }
+      let(:publishing_api_base_path) { '/hmrc-internal-manuals/some-slug' }
+
+      it 'issues a put_item request to the publishing api to mark the manual as gone' do
+        stub_default_publishing_api_put
+
+        subject.save!
+
+        assert_publishing_api_put_item(publishing_api_base_path, gone_manual_for_publishing_api)
+      end
+    end
+
+    def ignoring(error_class, &block)
+      block.call
+    rescue error_class
+    end
+  end
+end

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -42,6 +42,45 @@ describe PublishingAPIRemovedManual do
     end
   end
 
+  describe '#sections' do
+    subject(:removed_manual) { described_class.new('some-manual-slug') }
+
+    it 'asks rummager for all the hmrc manual sections under its slug' do
+      rummager_query = stub_request(:get, %r{/unified_search.json})
+        .with(query: search_for_sections_rummager_query('some-manual-slug'))
+        .to_return(body: no_manual_sections_rummager_json_result)
+
+      subject.sections
+
+      assert_requested rummager_query
+    end
+
+    it 'exposes each result from rummager as a PublishingAPIRemovedSection' do
+      stub_request(:get, %r{/unified_search.json})
+        .to_return(body: two_manual_sections_rummager_json_result('some-manual-slug'))
+
+      sections = subject.sections
+      expect(sections.size).to eq(2)
+
+      expect(sections.first).to be_a PublishingAPIRemovedSection
+      expect(sections.first.manual_slug).to eq('some-manual-slug')
+      expect(sections.first.section_slug).to eq('section-1')
+
+      expect(sections.last).to be_a PublishingAPIRemovedSection
+      expect(sections.last.manual_slug).to eq('some-manual-slug')
+      expect(sections.last.section_slug).to eq('section-2')
+    end
+
+    it 'exposes the error from rummager if the rummager call fails' do
+      stub_request(:get, %r{/unified_search.json})
+        .to_return(status: 503, body: '{"error":"arg!"}')
+
+      expect {
+        subject.sections
+      }.to raise_error(GdsApi::BaseError)
+    end
+  end
+
   describe '#save!' do
     include GdsApi::TestHelpers::PublishingApi
     include GdsApi::TestHelpers::Rummager

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -58,7 +58,7 @@ describe PublishingAPIRemovedManual do
       it 'does not communicate with the publishing api' do
         publishing_api_stub = stub_default_publishing_api_put
 
-        ignoring(ValidationError) { subject.save! }
+        ignoring_error(ValidationError) { subject.save! }
 
         assert_not_requested publishing_api_stub
       end
@@ -80,11 +80,6 @@ describe PublishingAPIRemovedManual do
         #      once https://github.com/alphagov/gds-api-adapters/pull/362 has been merged
         assert_requested(:delete, %r{#{Plek.new.find('search')}/documents#{publishing_api_base_path}})
       end
-    end
-
-    def ignoring(error_class, &block)
-      block.call
-    rescue error_class
     end
   end
 end

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api'
+require 'gds_api/test_helpers/rummager'
 
 describe PublishingAPIRemovedSection do
   describe '.from_rummager_result' do
@@ -74,6 +75,7 @@ describe PublishingAPIRemovedSection do
 
   describe '#save!' do
     include GdsApi::TestHelpers::PublishingApi
+    include GdsApi::TestHelpers::Rummager
 
     describe 'for an invalid manual section' do
       subject(:removed_manual_section) { described_class.new('this_is_not_acc3ptABLE!', 'is it?') }
@@ -99,10 +101,14 @@ describe PublishingAPIRemovedSection do
 
       it 'issues a put_item request to the publishing api to mark the manual section as gone' do
         stub_default_publishing_api_put
+        stub_any_rummager_delete
 
         subject.save!
 
         assert_publishing_api_put_item(publishing_api_base_path, gone_manual_section_for_publishing_api)
+        # TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`
+        #      once https://github.com/alphagov/gds-api-adapters/pull/362 has been merged
+        assert_requested(:delete, %r{#{Plek.new.find('search')}/documents#{publishing_api_base_path}})
       end
     end
   end

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api'
+
+
+describe PublishingAPIRemovedSection do
+  describe 'validations' do
+    context 'on section_slug' do
+      it 'is invalid when it is missing' do
+        expect(described_class.new('a-manual-slug', nil)).not_to be_valid
+      end
+
+      it 'is invalid when it does not match the valid_slug/pattern' do
+        expect(described_class.new('a-manual-sug', "1Som\nSłu9G!")).not_to be_valid
+      end
+    end
+
+    context 'on manual_slug' do
+      it 'is invalid when it is missing' do
+        expect(described_class.new(nil, 'a-section-slug')).not_to be_valid
+      end
+
+      it 'is invalid when it does not match the valid_slug/pattern' do
+        expect(described_class.new("1Som\nSłu9G!", 'a-section-slug')).not_to be_valid
+      end
+    end
+  end
+
+  describe '#to_h' do
+    let(:removed_manual_section) { described_class.new('some-manual', 'some-section') }
+    subject(:removed_manual_section_as_hash) { removed_manual_section.to_h }
+
+    it 'is a "gone" format object' do
+      expect(subject[:format]).to eq('gone')
+    end
+
+    it 'is published by the "hmrc-manuals-api" app' do
+      expect(subject[:publishing_app]).to eq('hmrc-manuals-api')
+    end
+
+    it 'is a major update' do
+      expect(subject[:update_type]).to eq('major')
+    end
+
+    it 'has one routes' do
+      expect(subject[:routes].size).to eq(1)
+    end
+
+    it 'includes the base_path of the manual section as an exact path in routes' do
+      expect(subject[:routes]).to include({ path: removed_manual_section.base_path, type: :exact })
+    end
+  end
+
+  describe '#save!' do
+    include GdsApi::TestHelpers::PublishingApi
+
+    describe 'for an invalid manual section' do
+      subject(:removed_manual_section) { described_class.new('this_is_not_acc3ptABLE!', 'is it?') }
+
+      it 'raises a validation error' do
+        expect {
+          subject.save!
+        }.to raise_error(ValidationError)
+      end
+
+      it 'does not communicate with the publishing api' do
+        publishing_api_stub = stub_default_publishing_api_put
+
+        ignoring_error(ValidationError) { subject.save! }
+
+        assert_not_requested publishing_api_stub
+      end
+    end
+
+    describe 'for a valid manual section' do
+      subject(:removed_manual_section) { described_class.new('some-manual', 'some-section') }
+      let(:publishing_api_base_path) { '/hmrc-internal-manuals/some-manual/some-section' }
+
+      it 'issues a put_item request to the publishing api to mark the manual section as gone' do
+        stub_default_publishing_api_put
+
+        subject.save!
+
+        assert_publishing_api_put_item(publishing_api_base_path, gone_manual_section_for_publishing_api)
+      end
+    end
+  end
+end

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api'
 
-
 describe PublishingAPIRemovedSection do
   describe 'validations' do
     context 'on section_slug' do

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -2,6 +2,29 @@ require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api'
 
 describe PublishingAPIRemovedSection do
+  describe '.from_rummager_result' do
+    let(:rummager_json) { single_section_parsed_rummager_json_result('manual-slug', 'section-slug') }
+
+    it 'extracts the manual and section slugs from the link attribute' do
+      section = described_class.from_rummager_result(rummager_json)
+      expect(section).to be_a described_class
+      expect(section.manual_slug).to eq('manual-slug')
+      expect(section.section_slug).to eq('section-slug')
+    end
+
+    it 'raises an InvalidJSONError if the json object has no link attribute' do
+      expect {
+        described_class.from_rummager_result(rummager_json.except('link'))
+      }.to raise_error(InvalidJSONError)
+    end
+
+    it 'raises an InvalidPathError if the link attribute cannot be used to extract slugs' do
+      expect {
+        described_class.from_rummager_result(rummager_json.merge('link' => '/oh-my/what-a-hat/'))
+      }.to raise_error(InvalidPathError)
+    end
+  end
+
   describe 'validations' do
     context 'on section_slug' do
       it 'is invalid when it is missing' do

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -13,11 +13,57 @@ describe PublishingAPISection do
     end
   end
 
+  describe '.extract_slugs_from_path' do
+    it 'finds the first path segment after the base path segment as the manual slug' do
+      extracted_slugs = described_class.extract_slugs_from_path('/hmrc-internal-manuals/what-a-slug/for-a-section')
+      expect(extracted_slugs[:manual]).to eq('what-a-slug')
+    end
+
+    it 'finds the second path segment after the base path segment as the section slug' do
+      extracted_slugs = described_class.extract_slugs_from_path('/hmrc-internal-manuals/what-a-slug/for-a-section')
+      expect(extracted_slugs[:section]).to eq('for-a-section')
+    end
+
+    it 'ignores trailing slashes' do
+      extracted_slugs = described_class.extract_slugs_from_path('/hmrc-internal-manuals/what-a-slug/for-a-section/')
+      expect(extracted_slugs[:section]).to eq('for-a-section')
+    end
+
+    it 'ignores path segments after the second one' do
+      extracted_slugs = described_class.extract_slugs_from_path('/hmrc-internal-manuals/what-a-slug/for-a-section/and-another/thing')
+      expect(extracted_slugs[:section]).to eq('for-a-section')
+    end
+
+    it 'raises an InvalidPathErrorInvalidPathError exception if the path is blank' do
+      expect {
+        described_class.extract_slugs_from_path('')
+      }.to raise_error(InvalidPathError)
+    end
+
+    it 'raises an InvalidPathError exception if the link does not start with the base path segment' do
+      expect {
+        described_class.extract_slugs_from_path('/fco-travel-advice/dont-go-back-to-rockville')
+      }.to raise_error(InvalidPathError)
+    end
+
+    it 'raises an InvalidPathError exception if the link does start with the base path segment, but has no 2nd path segment' do
+      expect {
+        described_class.extract_slugs_from_path('/hmrc-internal-manuals/')
+      }.to raise_error(InvalidPathError)
+    end
+
+    it 'raises an InvalidPathError exception if the path does start with the base path segment, but has no 3rd path segment' do
+      expect {
+        described_class.extract_slugs_from_path('/hmrc-internal-manuals/what-a-slug')
+      }.to raise_error(InvalidPathError)
+    end
+  end
+
   subject(:publishing_api_section) {
     PublishingAPISection.new(manual_slug, section_slug, attributes, options)
   }
   let(:manual_slug) { 'some-slug' }
-  let(:section_slug) { 'some_id' } 
+  let(:section_slug) { 'some_id' }
   let(:options) { { known_manual_slugs: known_manual_slugs } }
   let(:known_manual_slugs) { [] }
 

--- a/spec/support/ignoring_errors.rb
+++ b/spec/support/ignoring_errors.rb
@@ -1,0 +1,9 @@
+module IgnoringError
+  def ignoring_error(error_class, &block)
+    block.call
+  rescue error_class
+  end
+
+end
+
+RSpec.configuration.include IgnoringError

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -124,6 +124,24 @@ module PublishingApiDataHelpers
       ]
     }.merge(options)
   end
+
+  def gone_manual_for_publishing_api(slug: 'some-slug')
+    {
+      'format' => 'gone',
+      'publishing_app' => 'hmrc-manuals-api',
+      'update_type' => 'major',
+      'routes' => [
+        {
+          'path' => "/hmrc-internal-manuals/#{slug}",
+          'type' => 'exact',
+        },
+        {
+          'path' => "/hmrc-internal-manuals/#{slug}/updates",
+          'type' => 'exact',
+        },
+      ],
+    }
+  end
 end
 
 RSpec.configuration.include PublishingApiDataHelpers

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -142,6 +142,20 @@ module PublishingApiDataHelpers
       ],
     }
   end
+
+  def gone_manual_section_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section')
+    {
+      'format' => 'gone',
+      'publishing_app' => 'hmrc-manuals-api',
+      'update_type' => 'major',
+      'routes' => [
+        {
+          'path' => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
+          'type' => 'exact',
+        },
+      ],
+    }
+  end
 end
 
 RSpec.configuration.include PublishingApiDataHelpers

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -33,6 +33,26 @@ module RummagerHelpers
     }
   end
 
+  def search_for_sections_rummager_query(manual_slug)
+    {
+      'filter_format' => 'hmrc_manual_section',
+      'filter_organisations' => ['hm-revenue-customs'],
+      'filter_manual' => "/hmrc-internal-manuals/#{manual_slug}"
+    }
+  end
+
+  def no_manual_sections_rummager_json_result
+    <<-JSON.strip_heredoc
+      {
+        "results":[],
+        "total":0,
+        "start":0,
+        "facets":{},
+        "suggested_queries":[]
+      }
+    JSON
+  end
+
   def single_section_parsed_rummager_json_result(manual_slug, section_slug = 'section-1')
     {
       "format" => "hmrc_manual_section",
@@ -53,6 +73,57 @@ module RummagerHelpers
       "_id" => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
       "document_type" => "hmrc_manual_section"
     }
+  end
+
+  def two_manual_sections_rummager_json_result(manual_slug)
+    <<-JSON.strip_heredoc
+      {
+        "results":[
+          {
+            "format":"hmrc_manual_section",
+            "link":"/hmrc-internal-manuals/#{manual_slug}/section-1",
+            "organisations":[
+              {
+                "slug":"hm-revenue-customs",
+                "title":"HM Revenue & Customs",
+                "acronym":"HMRC",
+                "organisation_state":"live",
+                "link":"/government/organisations/hm-revenue-customs"
+              }
+            ],
+            "public_timestamp":"2015-02-03T16:30:33+00:00",
+            "title":"section 1",
+            "index":"mainstream",
+            "es_score":null,
+            "_id":"/hmrc-internal-manuals/#{manual_slug}/section-1",
+            "document_type":"hmrc_manual_section"
+          },
+          {
+            "format":"hmrc_manual_section",
+            "link":"/hmrc-internal-manuals/#{manual_slug}/section-2",
+            "organisations":[
+              {
+                "slug":"hm-revenue-customs",
+                "title":"HM Revenue & Customs",
+                "acronym":"HMRC",
+                "organisation_state":"live",
+                "link":"/government/organisations/hm-revenue-customs"
+              }
+            ],
+            "public_timestamp":"2015-02-10T15:56:49+00:00",
+            "title":"section 2",
+            "index":"mainstream",
+            "es_score":null,
+            "_id":"/hmrc-internal-manuals/#{manual_slug}/section-2",
+            "document_type":"hmrc_manual_section"
+          }
+        ],
+        "total":2,
+        "start":0,
+        "facets":{},
+        "suggested_queries":[]
+      }
+    JSON
   end
 end
 

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -32,6 +32,28 @@ module RummagerHelpers
       'format'                 => 'hmrc_manual_section',
     }
   end
+
+  def single_section_parsed_rummager_json_result(manual_slug, section_slug = 'section-1')
+    {
+      "format" => "hmrc_manual_section",
+      "link" => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
+      "organisations" => [
+        {
+          "slug" => "hm-revenue-customs",
+          "title" => "HM Revenue & Customs",
+          "acronym" => "HMRC",
+          "organisation_state" => "live",
+          "link" => "/government/organisations/hm-revenue-customs"
+        }
+      ],
+      "public_timestamp" => "2015-02-03T16:30:33+00:00",
+      "title" => "section 1",
+      "index" => "mainstream",
+      "es_score" => nil,
+      "_id" => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
+      "document_type" => "hmrc_manual_section"
+    }
+  end
 end
 
 RSpec.configuration.include(RummagerHelpers)


### PR DESCRIPTION
This is the code part (Acceptance criteria 2) of https://trello.com/c/Unsoan0D/61-clean-up-test-hmrc-manuals-in-production

The goal is to be able to run a script that will remove a published manual.  Removal here means to push a "gone" object over the manual in publishing-api, ask rummager to delete the manual, and then do the same for any sections that live "under" the manual.  There's no publishing-api method to find a section for a manual, so we issue a rummager search to do this.

The script is a rake task to be invoked as:

    rake remove_hmrc_manuals[slug-to-remove-1,slug-to-remove-2,...,slug-to-remove-n]

Note that because we've used standard rake arguments, you can't put spaces between the commas :(