### PR TITLE
Include base_path's leading slash in request

### DIFF
--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -44,10 +44,6 @@ class PublishingAPIRemovedManual
     PublishingAPIManual.base_path(@slug)
   end
 
-  def base_path_for_rummager
-    base_path.sub(/\A\//,'')
-  end
-
   def updates_path
     PublishingAPIManual.updates_path(@slug)
   end
@@ -56,7 +52,7 @@ class PublishingAPIRemovedManual
     raise ValidationError, "manual to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
-    HMRCManualsAPI.rummager.delete_document(MANUAL_FORMAT, base_path_for_rummager)
+    HMRCManualsAPI.rummager.delete_document(MANUAL_FORMAT, base_path)
 
     publishing_api_response
   end

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -38,15 +38,11 @@ class PublishingAPIRemovedSection
     PublishingAPISection.base_path(@manual_slug, @section_slug)
   end
 
-  def base_path_for_rummager
-    base_path.sub(/\A\//,'')
-  end
-
   def save!
     raise ValidationError, "manual section to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = HMRCManualsAPI.publishing_api.put_content_item(base_path, to_h)
 
-    HMRCManualsAPI.rummager.delete_document(SECTION_FORMAT, base_path_for_rummager)
+    HMRCManualsAPI.rummager.delete_document(SECTION_FORMAT, base_path)
 
     publishing_api_response
   end

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -153,7 +153,7 @@ describe PublishingAPIRemovedManual do
 
         #TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`
         #      once https://github.com/alphagov/gds-api-adapters/pull/362 has been merged
-        assert_requested(:delete, %r{#{Plek.new.find('search')}/documents#{publishing_api_base_path}})
+        assert_requested(:delete, %r{#{Plek.new.find('search')}/documents/#{publishing_api_base_path}})
       end
     end
   end

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -145,7 +145,7 @@ describe PublishingAPIRemovedSection do
         assert_publishing_api_put_item(publishing_api_base_path, gone_manual_section_for_publishing_api)
         # TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`
         #      once https://github.com/alphagov/gds-api-adapters/pull/362 has been merged
-        assert_requested(:delete, %r{#{Plek.new.find('search')}/documents#{publishing_api_base_path}})
+        assert_requested(:delete, %r{#{Plek.new.find('search')}/documents/#{publishing_api_base_path}})
       end
     end
   end


### PR DESCRIPTION
Rummager identifies HMRC Manuals and Sections by their path including the leading slash.

It looks weird, but Rummager requests with these identifiers in their paths should include the leading slash and therefore contain a double slash ("//").