### PR TITLE
Explain content_id in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ Additionally, users of the API are required to follow the styleguide for slugs:
 
 Section IDs are validated to ensure that they can be converted to slugs by simply making them lowercase.
 
+## Content IDs
+
+Both manuals and sections have a field `content_id`, which will be required in
+the future.
+
+This is a UUID string as described in [RFC 4122](https://www.ietf.org/rfc/rfc4122.txt) ([Wiki](https://en.wikipedia.org/wiki/Universally_unique_identifier)). It is
+[validated using this regex](https://github.com/alphagov/publishing-api/blob/1bd2c3d2aaa4681fe6286548aa16a4b5f66367c9/app/validators/uuid_validator.rb#L10-L24).
+
+For example: "30737dba-17f1-49b4-aff8-6dd4bff7fdca".
+
+This is a unique identifier for the piece of content. It is used as the reference
+with which content items can reference other content items on GOV.UK. For example,
+it is used for [tagging to topics](https://www.gov.uk/topic).
+
+Manuals and sections should always have a consistent `content_id`. It is not possible
+to send a previously-published document with the same slug but a different `content_id`.
+
+Currently, when a manual or section doesn't have a `content_id`, one will be
+generated for it. This generated UUID is non-random and based on the `base_path`
+of the item.
+
 ## Markup
 
 All `body` attributes in manuals or manual sections may contain

--- a/public/json_examples/requests/employment-income-manual.json
+++ b/public/json_examples/requests/employment-income-manual.json
@@ -1,6 +1,7 @@
 {
   // Manual
   "title": "Employment Income Manual",
+  "content_id": "c26389b9-6aaa-4821-be84-0141d2eb7225",
   "description": "A guide to the Income Tax (Earnings and Pensions) Act 2003",
   // public_updated_at should be updated on the manual whenever a change to a
   // part of the manual is made, but can be done once for a batch of changes.

--- a/public/json_examples/requests/employment-income-manual/eim11200.json
+++ b/public/json_examples/requests/employment-income-manual/eim11200.json
@@ -1,5 +1,6 @@
 {
   "title": "Incentive award schemes: what are they?",
+  "content_id": "9578eafe-c68e-4dd0-a891-4c450c6a4e77",
   "description": "",
   "public_updated_at": "2014-01-23T00:00:00+01:00",
   "update_type": "major",

--- a/public/json_examples/requests/employment-income-manual/eim11800.json
+++ b/public/json_examples/requests/employment-income-manual/eim11800.json
@@ -1,5 +1,6 @@
 {
   "title": "PAYE special types of payment: contents",
+  "content_id": "1da0cc3c-b039-4802-a951-b427bf5db619",
   "description": "Optional",
   // Ideally, it should be when the content was last changed, which will often
   // be when this request is made, but it might be in the past for content

--- a/public/json_examples/requests/employment-income-manual/eim25525.json
+++ b/public/json_examples/requests/employment-income-manual/eim25525.json
@@ -1,5 +1,6 @@
 {
   "title": "Car fuel benefit: charge not related to cost of providing fuel",
+  "content_id": "e24dc96f-abc6-4f31-9a6b-8c277d3adbcf",
   "description": "Optional.",
   // Ideally, it should be when the content was last changed, which will often
   // be when this request is made, but it might be in the past for content


### PR DESCRIPTION
This commit adds the content_id to the JSON examples and attempts to explain the content_id in the readme.

Some of it is lifted from https://github.com/alphagov/content-store/blob/master/doc/content_item_fields.md#content_id

/cc @rboulton 