### PR TITLE
Generate content id when absent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'govspeak', '3.0.0'
 
 gem 'sidekiq', '3.4.2'
 
+gem 'uuidtools', '2.1.5'
+
 group :development do
   gem "foreman", "0.78.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uuidtools (2.1.5)
     warden (1.2.3)
       rack (>= 1.0)
     warden-oauth2 (0.0.1)
@@ -247,4 +248,8 @@ DEPENDENCIES
   simplecov (= 0.8.2)
   simplecov-rcov (= 0.2.3)
   unicorn (= 4.8.3)
+  uuidtools (= 2.1.5)
   webmock (= 1.18.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/models/helpers/publishing_api_helpers.rb
+++ b/app/models/helpers/publishing_api_helpers.rb
@@ -12,5 +12,19 @@ module Helpers
       )
       attributes
     end
+
+    def add_absent_content_id(attributes)
+      unless attributes["content_id"]
+        attributes["content_id"] = base_path_uuid
+      end
+
+      attributes
+    end
+
+    private
+
+    def base_path_uuid
+      UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, base_path).to_s
+    end
   end
 end

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -39,6 +39,7 @@ class PublishingAPIManual
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_organisations_to_details(enriched_data)
       enriched_data = add_base_path_to_change_notes(enriched_data)
+      enriched_data = add_absent_content_id(enriched_data)
 
       if HMRCManualsAPI::Application.config.publish_topics
         enriched_data = add_topic_links(enriched_data)

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -36,6 +36,7 @@ class PublishingAPISection
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_breadcrumbs(enriched_data)
       enriched_data = add_base_path_to_manual(enriched_data)
+      enriched_data = add_absent_content_id(enriched_data)
       add_organisations_to_details(enriched_data)
     end
   end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -86,6 +86,24 @@ describe PublishingAPIManual do
 
       it { should be_valid_against_schema('hmrc_manual') }
     end
+
+    context "when no content_id is present" do
+      it "should be generated from base_path" do
+        expect(publishing_api_manual.manual.manual_attributes["content_id"]).to be_nil
+
+        uuid = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, publishing_api_manual.base_path).to_s
+        expect(publishing_api_manual.to_h["content_id"]).to eq(uuid)
+      end
+    end
+
+    context "when content_id is present" do
+      let(:content_id) { SecureRandom.uuid }
+      let(:attributes) { valid_manual.merge("content_id" => content_id) }
+
+      it "should be preserved" do
+        expect(publishing_api_manual.to_h["content_id"]).to eq(content_id)
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -81,6 +81,26 @@ describe PublishingAPISection do
 
       it { should be_valid_against_schema('hmrc_manual_section') }
     end
+
+    context "when no content_id is present" do
+      let(:attributes) { valid_section }
+
+      it "should be generated from base_path" do
+        expect(publishing_api_section.section_attributes["content_id"]).to be_nil
+
+        uuid = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, publishing_api_section.base_path).to_s
+        expect(publishing_api_section.to_h["content_id"]).to eq(uuid)
+      end
+    end
+
+    context "when content_id is present" do
+      let(:content_id) { SecureRandom.uuid }
+      let(:attributes) { valid_section.merge("content_id" => content_id) }
+
+      it "should be preserved" do
+        expect(publishing_api_section.to_h["content_id"]).to eq(content_id)
+      end
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
This is a rough proposal for working around the missing `content_id` values for `hrmc_manual` and `hmrc_manual_section` formats.
Full story here https://trello.com/c/pULByuHs/393-fix-invalid-content-store-data
The uuid is generated consistently from the `base_path` of the manual/section, it's a valid v5 uuid as per RFC4122. It's also discernible from a typical `SecureRandom.uuid` as these are v4.

/cc @jennyd Can we talk about this when you have a moment.