### PR TITLE
Generate content id when absent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'govspeak', '3.0.0'
 
 gem 'sidekiq', '3.4.2'
 
+gem 'uuidtools', '2.1.5'
+
 group :development do
   gem "foreman", "0.78.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uuidtools (2.1.5)
     warden (1.2.3)
       rack (>= 1.0)
     warden-oauth2 (0.0.1)
@@ -247,4 +248,5 @@ DEPENDENCIES
   simplecov (= 0.8.2)
   simplecov-rcov (= 0.2.3)
   unicorn (= 4.8.3)
+  uuidtools (= 2.1.5)
   webmock (= 1.18.0)

--- a/app/models/helpers/publishing_api_helpers.rb
+++ b/app/models/helpers/publishing_api_helpers.rb
@@ -12,5 +12,17 @@ module Helpers
       )
       attributes
     end
+
+    def add_absent_content_id(attributes)
+      unless attributes["content_id"]
+        attributes["content_id"] = base_path_uuid
+      end
+
+      attributes
+    end
+
+    def base_path_uuid
+      UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, base_path).to_s
+    end
   end
 end

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -39,6 +39,7 @@ class PublishingAPIManual
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_organisations_to_details(enriched_data)
       enriched_data = add_base_path_to_change_notes(enriched_data)
+      enriched_data = add_absent_content_id(enriched_data)
 
       if HMRCManualsAPI::Application.config.publish_topics
         enriched_data = add_topic_links(enriched_data)

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -3,6 +3,7 @@ require 'valid_slug/pattern'
 
 class PublishingAPIRemovedManual
   include ActiveModel::Validations
+  include Helpers::PublishingAPIHelpers
 
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
@@ -30,6 +31,7 @@ class PublishingAPIRemovedManual
 
   def to_h
     @_to_h ||= {
+      content_id: base_path_uuid,
       format: 'gone',
       publishing_app: 'hmrc-manuals-api',
       update_type: 'major',

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -3,6 +3,7 @@ require 'valid_slug/pattern'
 
 class PublishingAPIRemovedSection
   include ActiveModel::Validations
+  include Helpers::PublishingAPIHelpers
 
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
@@ -25,6 +26,7 @@ class PublishingAPIRemovedSection
 
   def to_h
     @_to_h ||= {
+      content_id: base_path_uuid,
       format: 'gone',
       publishing_app: 'hmrc-manuals-api',
       update_type: 'major',

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -36,6 +36,7 @@ class PublishingAPISection
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_breadcrumbs(enriched_data)
       enriched_data = add_base_path_to_manual(enriched_data)
+      enriched_data = add_absent_content_id(enriched_data)
       add_organisations_to_details(enriched_data)
     end
   end

--- a/spec/models/helpers/publishing_api_helpers_spec.rb
+++ b/spec/models/helpers/publishing_api_helpers_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.configure do |c|
+  c.include Helpers::PublishingAPIHelpers
+end
+
+RSpec.describe "Helpers::PublishingAPIHelpers" do
+  describe "base_path_uuid" do
+    before do
+      allow_any_instance_of(Helpers::PublishingAPIHelpers)
+        .to receive(:base_path)
+        .and_return("/hmrc-internal-manuals/business-income-manual")
+    end
+
+    it "generates a consistent uuid from base_path" do
+      expect(base_path_uuid).to eq("6c88e946-c722-5e73-9d6a-71da770d27a9")
+    end
+  end
+end

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -86,6 +86,24 @@ describe PublishingAPIManual do
 
       it { should be_valid_against_schema('hmrc_manual') }
     end
+
+    context "when no content_id is present" do
+      it "should be generated from base_path" do
+        expect(publishing_api_manual.manual.manual_attributes["content_id"]).to be_nil
+
+        uuid = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, publishing_api_manual.base_path).to_s
+        expect(publishing_api_manual.to_h["content_id"]).to eq(uuid)
+      end
+    end
+
+    context "when content_id is present" do
+      let(:content_id) { SecureRandom.uuid }
+      let(:attributes) { valid_manual.merge("content_id" => content_id) }
+
+      it "should be preserved" do
+        expect(publishing_api_manual.to_h["content_id"]).to eq(content_id)
+      end
+    end
   end
 
   describe 'validations' do

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -71,6 +71,11 @@ describe PublishingAPIRemovedManual do
     it 'includes the updates_path of the manual as an exact path in routes' do
       expect(subject[:routes]).to include({ path: removed_manual.updates_path, type: :exact })
     end
+
+    it "generates a uuid from base_path" do
+      uuid = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, removed_manual.base_path).to_s
+      expect(subject[:content_id]).to eq(uuid)
+    end
   end
 
   describe '#sections' do

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -103,6 +103,11 @@ describe PublishingAPIRemovedSection do
     it 'includes the base_path of the manual section as an exact path in routes' do
       expect(subject[:routes]).to include({ path: removed_manual_section.base_path, type: :exact })
     end
+
+    it "generates a uuid from base_path" do
+      uuid = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, removed_manual_section.base_path).to_s
+      expect(subject[:content_id]).to eq(uuid)
+    end
   end
 
   describe '#save!' do

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -81,6 +81,26 @@ describe PublishingAPISection do
 
       it { should be_valid_against_schema('hmrc_manual_section') }
     end
+
+    context "when no content_id is present" do
+      let(:attributes) { valid_section }
+
+      it "should be generated from base_path" do
+        expect(publishing_api_section.section_attributes["content_id"]).to be_nil
+
+        uuid = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, publishing_api_section.base_path).to_s
+        expect(publishing_api_section.to_h["content_id"]).to eq(uuid)
+      end
+    end
+
+    context "when content_id is present" do
+      let(:content_id) { SecureRandom.uuid }
+      let(:attributes) { valid_section.merge("content_id" => content_id) }
+
+      it "should be preserved" do
+        expect(publishing_api_section.to_h["content_id"]).to eq(content_id)
+      end
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
This is a proposal for working around the missing `content_id` values for `hrmc_manual` and `hmrc_manual_section` formats in the content store.
Full story here https://trello.com/c/pULByuHs/393-fix-invalid-content-store-data
Original PR https://github.com/alphagov/hmrc-manuals-api/pull/121

- The uuid is generated consistently from the `base_path` of the manual/section, it's a valid v5 uuid as per RFC4122. It's also discernible from a typical SecureRandom.uuid as these are v4.
- Gone items get a `content_id` generated by the same method.