### PR TITLE
Remove all sections when removing manual

### DIFF
--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -42,7 +42,8 @@ class RummagerSection < RummagerBase
     {
       'filter_format' => SECTION_FORMAT,
       'filter_organisations' => [GOVUK_HMRC_SLUG],
-      'filter_manual' => manual_path
+      'filter_manual' => manual_path,
+      'count' => '5000',
     }
   end
 end

--- a/lib/tasks/remove_manuals.rake
+++ b/lib/tasks/remove_manuals.rake
@@ -24,11 +24,11 @@ task :remove_hmrc_manuals, [] => :environment do |_task, args|
     slugs.each do |manual_slug|
       print "Removing manual '#{manual_slug}': "
       manual = PublishingAPIRemovedManual.new(manual_slug)
-      remove_and_output(manual)
       manual.sections.each do |section|
         print "  Removing section '#{manual_slug}/#{section.section_slug}'"
         remove_and_output(section)
       end
+      remove_and_output(manual)
     end
   end
 end

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -37,7 +37,8 @@ module RummagerHelpers
     {
       'filter_format' => 'hmrc_manual_section',
       'filter_organisations' => ['hm-revenue-customs'],
-      'filter_manual' => "/hmrc-internal-manuals/#{manual_slug}"
+      'filter_manual' => "/hmrc-internal-manuals/#{manual_slug}",
+      'count' => '5000',
     }
   end
 


### PR DESCRIPTION
Rummager defaults to returning 10 results if a count isn't specified, so the
rake task to remove a manual and all its sections was only removing up to 10
sections and leaving the rest. The largest manuals we know of have less than
3000 sections, so a limit of 5000 should always be large enough.

Also withdraw the manual after its sections, so that if the script exits early for some reason it won't error on a second run.