### PR TITLE
Resolve issue with autoloading `API::UserController`

### DIFF
--- a/config/initializers/acronym.rb
+++ b/config/initializers/acronym.rb
@@ -1,5 +1,4 @@
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym 'HTML'
-  inflect.acronym 'API'
   inflect.acronym 'HMRC'
 end


### PR DESCRIPTION
Prior to this change, we were experiencing problems with this
application inflecting `Api` to `API` and thus failing to autoload the
`gds-sso` supplied `API::UserController`.

Removing the inflection resolves this issue and the tests remain green.
I did spend some time trying to ascertain whether inflecting `API` was
important and didn't find any further evidence within this application.

cc @jennyd, @benilovj 