### PR TITLE
Use `Services` module for external APIs

### DIFF
--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -8,7 +8,7 @@ class PublishingAPIRemovedManual
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
     format: MANUAL_FORMAT,
-    content_store: HMRCManualsAPI.content_store,
+    content_store: Services.content_store,
     unless: -> { errors[:slug].present? }
 
   attr_reader :slug
@@ -25,7 +25,7 @@ class PublishingAPIRemovedManual
 
   def sections_from_rummager
     query = RummagerSection.search_query(base_path)
-    HMRCManualsAPI.rummager.unified_search(query).results
+    Services.rummager.unified_search(query).results
   end
   private :sections_from_rummager
 
@@ -61,7 +61,7 @@ class PublishingAPIRemovedManual
   def save!
     raise ValidationError, "manual to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = PublishingAPINotifier.new(self).notify
-    HMRCManualsAPI.rummager.delete_document(MANUAL_FORMAT, base_path)
+    Services.rummager.delete_document(MANUAL_FORMAT, base_path)
     publishing_api_response
   end
 

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -8,7 +8,7 @@ class PublishingAPIRemovedSection
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
     format: SECTION_FORMAT,
-    content_store: HMRCManualsAPI.content_store,
+    content_store: Services.content_store,
     unless: -> { errors[:manual_slug].present? || errors[:section_slug].present? }
 
   attr_reader :manual_slug, :section_slug
@@ -51,7 +51,7 @@ class PublishingAPIRemovedSection
   def save!
     raise ValidationError, "manual section to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = PublishingAPINotifier.new(self).notify
-    HMRCManualsAPI.rummager.delete_document(SECTION_FORMAT, base_path)
+    Services.rummager.delete_document(SECTION_FORMAT, base_path)
     publishing_api_response
   end
 

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -12,14 +12,14 @@ class PublishingAPINotifier
 
 private
   def put_content_item
-    HMRCManualsAPI.publishing_api.put_content(@document.content_id, @document.to_h)
+    Services.publishing_api.put_content(@document.content_id, @document.to_h)
   end
 
   def publish(options)
-    HMRCManualsAPI.publishing_api.publish(@document.content_id, @document.update_type, options)
+    Services.publishing_api.publish(@document.content_id, @document.update_type, options)
   end
 
   def put_links
-    HMRCManualsAPI.publishing_api.put_links(@document.content_id, @document.topic_links) if @document.send_topic_links?
+    Services.publishing_api.put_links(@document.content_id, @document.topic_links) if @document.send_topic_links?
   end
 end

--- a/app/workers/send_to_rummager_worker.rb
+++ b/app/workers/send_to_rummager_worker.rb
@@ -2,6 +2,6 @@ class SendToRummagerWorker
   include Sidekiq::Worker
 
   def perform(format, id, attributes)
-    HMRCManualsAPI.rummager.add_document(format, id, attributes)
+    Services.rummager.add_document(format, id, attributes)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,11 +14,6 @@ require "action_view/railtie"
 Bundler.require(*Rails.groups)
 
 module HMRCManualsAPI
-  mattr_accessor :content_register
-  mattr_accessor :publishing_api
-  mattr_accessor :rummager
-  mattr_accessor :content_store
-
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
@@ -40,5 +35,7 @@ module HMRCManualsAPI
 
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil
+
+    config.autoload_paths += Dir["#{config.root}/lib/**/"]
   end
 end

--- a/config/initializers/content_register.rb
+++ b/config/initializers/content_register.rb
@@ -1,3 +1,0 @@
-require 'gds_api/content_register'
-
-HMRCManualsAPI.content_register = GdsApi::ContentRegister.new(Plek.current.find('content-register'))

--- a/config/initializers/content_store.rb
+++ b/config/initializers/content_store.rb
@@ -1,3 +1,0 @@
-require 'gds_api/content_store'
-
-HMRCManualsAPI.content_store = GdsApi::ContentStore.new(Plek.current.find('content-store'))

--- a/config/initializers/publishing_api.rb
+++ b/config/initializers/publishing_api.rb
@@ -1,6 +1,0 @@
-require 'gds_api/publishing_api_v2'
-
-HMRCManualsAPI.publishing_api = GdsApi::PublishingApiV2.new(
-  Plek.new.find('publishing-api'),
-  bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
-)

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,3 +1,0 @@
-require 'gds_api/rummager'
-
-HMRCManualsAPI.rummager = GdsApi::Rummager.new(Plek.current.find('search'))

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,25 @@
+require 'gds_api/publishing_api_v2'
+require 'gds_api/content_register'
+require 'gds_api/rummager'
+require 'gds_api/content_store'
+
+module Services
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+  end
+
+  def self.content_register
+    @content_register ||= GdsApi::ContentRegister.new(Plek.current.find('content-register'))
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.current.find('search'))
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.current.find('content-store'))
+  end
+end

--- a/lib/tasks/manuals_to_topics.rake
+++ b/lib/tasks/manuals_to_topics.rake
@@ -2,7 +2,7 @@ require 'csv'
 
 desc "Map manual topic slugs to content IDs"
 task map_manual_topic_slugs_to_content_ids: :environment do
-  topics = HMRCManualsAPI.content_register.entries('topic').to_a
+  topics = Services.content_register.entries('topic').to_a
 
   csv = CSV.read("#{Rails.root}/lib/manuals_to_topics.csv")
 

--- a/lib/topics.rb
+++ b/lib/topics.rb
@@ -1,5 +1,5 @@
 class Topics
-  def initialize(manual_slug:, manuals_to_topics: MANUALS_TO_TOPICS, content_register: HMRCManualsAPI.content_register)
+  def initialize(manual_slug:, manuals_to_topics: MANUALS_TO_TOPICS, content_register: Services.content_register)
     @manual_slug = manual_slug
     @manuals_to_topics = manuals_to_topics
     @content_register = content_register

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -11,9 +11,9 @@ describe PublishingAPINotifier do
 
     context 'all requests get a 200 response' do
       it 'calls put_content, publish and send links and return a 200 response' do
-        expect(HMRCManualsAPI.publishing_api).to receive(:put_content).with(content_id, document_hash).and_return(successful_response)
-        expect(HMRCManualsAPI.publishing_api).to receive(:publish).with(content_id, 'major', {previous_version: 33}).and_return(successful_response)
-        expect(HMRCManualsAPI.publishing_api).to receive(:put_links).with(content_id, links_hash).and_return(successful_response)
+        expect(Services.publishing_api).to receive(:put_content).with(content_id, document_hash).and_return(successful_response)
+        expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', {previous_version: 33}).and_return(successful_response)
+        expect(Services.publishing_api).to receive(:put_links).with(content_id, links_hash).and_return(successful_response)
 
         response = PublishingAPINotifier.new(document).notify
         expect(response).to eq successful_response
@@ -21,9 +21,9 @@ describe PublishingAPINotifier do
 
       it 'does not send links if no links to send' do
         document = double PublishingAPIManual, content_id: content_id, to_h: document_hash, update_type: 'major', send_topic_links?: false, topic_links: links_hash
-        expect(HMRCManualsAPI.publishing_api).to receive(:put_content).with(content_id, document_hash).and_return(successful_response)
-        expect(HMRCManualsAPI.publishing_api).to receive(:publish).with(content_id, 'major', {previous_version: 33}).and_return(successful_response)
-        expect(HMRCManualsAPI.publishing_api).not_to receive(:put_links)
+        expect(Services.publishing_api).to receive(:put_content).with(content_id, document_hash).and_return(successful_response)
+        expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', {previous_version: 33}).and_return(successful_response)
+        expect(Services.publishing_api).not_to receive(:put_links)
 
         response = PublishingAPINotifier.new(document).notify
         expect(response).to eq successful_response


### PR DESCRIPTION
This app is using an old pattern to retain references to the API
clients. The `Services` module is simpler and is in use in most other
applications.