### PR TITLE
Conditionally add organisation to links hash of incoming manual updates

### DIFF
--- a/app/models/links_builder.rb
+++ b/app/models/links_builder.rb
@@ -1,0 +1,28 @@
+class LinksBuilder
+  def initialize(content_id)
+    @content_id = content_id
+    @built_links = {}
+  end
+
+  def build_links
+    @content_store_links = get_links
+    set_organistion
+    @built_links
+  end
+
+private
+  def get_links
+    Services.publishing_api.get_links(@content_id)
+  rescue GdsApi::HTTPNotFound
+    {}
+  end
+
+  def set_organistion
+    if @content_store_links["organisations"].present?
+      @built_links["organisations"] = @content_store_links["organisations"]
+    else
+      # Use HMRC content ID to set organisation
+      @built_links["organisations"] = ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+    end
+  end
+end

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -15,8 +15,9 @@ class PublishingAPIManual
 
   def initialize(slug, manual_attributes)
     @slug = slug
-    @manual_attributes = manual_attributes
+    @manual_attributes = Hash(manual_attributes)
     @manual = Manual.new(@manual_attributes)
+
     generate_content_id_if_absent
   end
 
@@ -35,10 +36,13 @@ class PublishingAPIManual
       })
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
-      enriched_data = add_organisations_to_details(enriched_data)
       enriched_data = add_base_path_to_change_notes(enriched_data)
       enriched_data
     end
+  end
+
+  def links
+    LinksBuilder.new(content_id).build_links
   end
 
   def content_id
@@ -89,9 +93,7 @@ class PublishingAPIManual
 
 private
   def generate_content_id_if_absent
-    if @manual_attributes.is_a?(Hash)
-      @manual_attributes["content_id"] = base_path_uuid unless @manual_attributes["content_id"]
-    end
+    @manual_attributes["content_id"] = base_path_uuid unless @manual_attributes["content_id"]
   end
 
   def add_base_path_to_child_section_groups(attributes)

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -60,7 +60,7 @@ class PublishingAPIRemovedManual
 
   def save!
     raise ValidationError, "manual to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
-    publishing_api_response = PublishingAPINotifier.new(self).notify
+    publishing_api_response = PublishingAPINotifier.new(self).notify(update_links: false)
     Services.rummager.delete_document(MANUAL_FORMAT, base_path)
     publishing_api_response
   end

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -50,7 +50,7 @@ class PublishingAPIRemovedSection
 
   def save!
     raise ValidationError, "manual section to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
-    publishing_api_response = PublishingAPINotifier.new(self).notify
+    publishing_api_response = PublishingAPINotifier.new(self).notify(update_links: false)
     Services.rummager.delete_document(SECTION_FORMAT, base_path)
     publishing_api_response
   end

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -36,8 +36,11 @@ class PublishingAPISection
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_breadcrumbs(enriched_data)
       enriched_data = add_base_path_to_manual(enriched_data)
-      add_organisations_to_details(enriched_data)
     end
+  end
+
+  def links
+    LinksBuilder.new(content_id).build_links
   end
 
   def content_id

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -3,15 +3,20 @@ class PublishingAPINotifier
     @document = document
   end
 
-  def notify
+  def notify(update_links: true)
     content_item = put_content_item
     publish(content_item.version)
+    put_links if update_links
     content_item
   end
 
 private
   def put_content_item
     Services.publishing_api.put_content(@document.content_id, @document.to_h)
+  end
+
+  def put_links
+    Services.publishing_api.put_links(@document.content_id, links: @document.links)
   end
 
   def publish(version)

--- a/spec/models/links_builder_spec.rb
+++ b/spec/models/links_builder_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe LinksBuilder do
+  describe "#build_links" do
+    let(:content_id) { "document-uuid" }
+
+    context "document already has linked organisation" do
+      before do
+        allow(Services.publishing_api).to receive(:get_links).with(content_id).and_return(
+          { "organisations" => ["some-org-uuid"] }
+        )
+      end
+
+      it "uses the existing organisation content ID" do
+        expect(LinksBuilder.new(content_id).build_links).to eq(
+          "organisations" => ["some-org-uuid"]
+        )
+      end
+    end
+
+    context "document does not have linked organisation" do
+      before do
+        allow(Services.publishing_api).to receive(:get_links).with(content_id).and_return(
+          {}
+        )
+      end
+
+      it "uses the default HMRC organisation content ID" do
+        expect(LinksBuilder.new(content_id).build_links).to eq(
+          "organisations" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+        )
+      end
+    end
+
+    context "no document found" do
+      before do
+        allow(Services.publishing_api).to receive(:get_links).with(content_id).and_raise(GdsApi::HTTPNotFound.new(404, 'some', 'error'))
+      end
+
+      it "uses the default HMRC organisation content ID" do
+        expect(LinksBuilder.new(content_id).build_links).to eq(
+          "organisations" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -5,6 +5,7 @@ require 'gds_api/test_helpers/rummager'
 describe 'manual sections resource' do
   include GdsApi::TestHelpers::PublishingApiV2
   include GdsApi::TestHelpers::Rummager
+  include LinksUpdateHelper
 
   let(:maximal_section_endpoint) {
     "/hmrc-manuals/#{maximal_manual_slug}/sections/#{maximal_section_slug}"
@@ -14,6 +15,8 @@ describe 'manual sections resource' do
     stub_publishing_api_put_content(maximal_section_content_id, {}, { body: {version: 788} })
     stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788}.to_json)
     stub_any_rummager_post
+    stub_publishing_api_get_links(maximal_section_content_id)
+    stub_put_default_organisation(maximal_section_content_id)
 
     put_json maximal_section_endpoint, maximal_section
 
@@ -29,21 +32,25 @@ describe 'manual sections resource' do
     stub_publishing_api_put_content(maximal_section_content_id, {}, { body: {version: 12} })
     stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 12}.to_json)
     stub_any_rummager_post
+    stub_publishing_api_get_links(maximal_section_content_id)
+    stub_put_default_organisation(maximal_section_content_id)
 
-    put maximal_section_endpoint, maximal_section.to_json,
-        headers = {'CONTENT_TYPE' => 'application/json',
-                   'HTTP_ACCEPT'  => 'text/plain',
-                   'HTTP_AUTHORIZATION' => 'Bearer 12345'}
+    put maximal_section_endpoint, maximal_section.to_json, {
+      'CONTENT_TYPE' => 'application/json',
+      'HTTP_ACCEPT'  => 'text/plain',
+      'HTTP_AUTHORIZATION' => 'Bearer 12345'
+    }
     expect(response.status).to eq(406)
   end
 
   it 'errors if the Content-Type header is not application/json' do
     stub_any_publishing_api_call
 
-    put maximal_section_endpoint, maximal_section.to_json,
-        headers = {'CONTENT_TYPE' => 'text/plain',
-                   'HTTP_ACCEPT'  => 'application/json',
-                   'HTTP_AUTHORIZATION' => 'Bearer 12345'}
+    put maximal_section_endpoint, maximal_section.to_json, {
+      'CONTENT_TYPE' => 'text/plain',
+      'HTTP_ACCEPT'  => 'application/json',
+      'HTTP_AUTHORIZATION' => 'Bearer 12345'
+    }
     expect(response.status).to eq(415)
   end
 
@@ -75,6 +82,8 @@ describe 'manual sections resource' do
     stub_publishing_api_put_content(maximal_section_content_id, {}, { body: { version: 788 } }) # This returns 200
     stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788}.to_json)
     stub_any_rummager_post_with_queueing_enabled # This returns 202, as it does in Production
+    stub_publishing_api_get_links(maximal_section_content_id)
+    stub_put_default_organisation(maximal_section_content_id)
 
     put_json maximal_section_endpoint, maximal_section
 

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -6,11 +6,14 @@ require 'gds_api/test_helpers/content_register'
 describe 'manuals resource' do
   include GdsApi::TestHelpers::PublishingApiV2
   include GdsApi::TestHelpers::Rummager
+  include LinksUpdateHelper
 
   it 'confirms update of the manual' do
     allow_any_instance_of(GdsApi::Response).to receive(:version)
     stub_any_publishing_api_call
     stub_any_rummager_post
+    stub_publishing_api_get_links(maximal_manual_content_id)
+    stub_put_default_organisation(maximal_manual_content_id)
 
     put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
@@ -45,6 +48,8 @@ describe 'manuals resource' do
     allow_any_instance_of(GdsApi::Response).to receive(:version)
     stub_any_publishing_api_call
     stub_any_rummager_post_with_queueing_enabled # This returns 202, as it does in Production
+    stub_publishing_api_get_links(maximal_manual_content_id)
+    stub_put_default_organisation(maximal_manual_content_id)
 
     put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
@@ -62,11 +67,14 @@ describe 'manuals resource' do
     allow_any_instance_of(GdsApi::Response).to receive(:version)
     stub_any_publishing_api_call
     stub_any_rummager_post
+    stub_publishing_api_get_links(maximal_manual_content_id)
+    stub_put_default_organisation(maximal_manual_content_id)
 
-    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json,
-        headers = {'CONTENT_TYPE' => 'application/json',
-                   'HTTP_ACCEPT'  => 'text/plain',
-                   'HTTP_AUTHORIZATION' => 'Bearer 12345'}
+    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json, {
+      'CONTENT_TYPE' => 'application/json',
+      'HTTP_ACCEPT' => 'text/plain',
+      'HTTP_AUTHORIZATION' => 'Bearer 12345'
+    }
     expect(response.status).to eq(406)
   end
 
@@ -74,10 +82,11 @@ describe 'manuals resource' do
     stub_any_publishing_api_call
     stub_any_rummager_post
 
-    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json,
-        headers = {'CONTENT_TYPE' => 'text/plain',
-                   'HTTP_ACCEPT'  => 'application/json',
-                   'HTTP_AUTHORIZATION' => 'Bearer 12345'}
+    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json, {
+      'CONTENT_TYPE' => 'text/plain',
+      'HTTP_ACCEPT'  => 'application/json',
+      'HTTP_AUTHORIZATION' => 'Bearer 12345'
+    }
     expect(response.status).to eq(415)
   end
 end

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -5,6 +5,7 @@ require 'gds_api/test_helpers/rummager'
 describe "validation" do
   include GdsApi::TestHelpers::PublishingApiV2
   include GdsApi::TestHelpers::Rummager
+  include LinksUpdateHelper
 
   let(:malformed_json) { "[" }
   let(:headers) { { 'Content-Type' => 'application/json', 'HTTP_AUTHORIZATION' => 'Bearer 12345678' } }
@@ -60,6 +61,9 @@ describe "validation" do
       it 'allows images with a relative path' do
         content_id = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, "/hmrc-internal-manuals/imaginary-slug").to_s
         stub_publishing_api_put_content(content_id, {}, { body: {version: 22} })
+        stub_publishing_api_get_links(content_id)
+        stub_put_default_organisation(content_id)
+
         stub_publishing_api_publish(content_id, { update_type: 'minor', previous_version: 22}.to_json)
         stub_any_rummager_post
 

--- a/spec/support/links_update_helper.rb
+++ b/spec/support/links_update_helper.rb
@@ -1,0 +1,13 @@
+module LinksUpdateHelper
+  def stub_publishing_api_get_links(content_id, body: { links: {} })
+    stub_request(:get, Plek.new.find('publishing-api') + "/v2/links/#{content_id}")
+      .to_return(body: body.to_json)
+  end
+
+  def stub_put_default_organisation(content_id)
+    stub_publishing_api_put_links(
+      content_id,
+      { links: { organisations: ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"] } }.to_json
+    )
+  end
+end

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -19,13 +19,6 @@ module PublishingApiDataHelpers
             ]
           }
         ],
-        "organisations" => [
-          {
-            "title" => "HM Revenue & Customs",
-            "abbreviation" => "HMRC",
-            "web_url" => "https://www.gov.uk/government/organisations/hm-revenue-customs"
-          }
-        ],
         "change_notes" => [
           {
             "base_path" => "/hmrc-internal-manuals/employment-income-manual/abc567",
@@ -91,13 +84,6 @@ module PublishingApiDataHelpers
                 "base_path" => "/hmrc-internal-manuals/employment-income-manual/123456"
               }
             ]
-          }
-        ],
-        "organisations" => [
-          {
-            "title" => "HM Revenue & Customs",
-            "abbreviation" => "HMRC",
-            "web_url" => "https://www.gov.uk/government/organisations/hm-revenue-customs"
           }
         ]
       },


### PR DESCRIPTION
When handling an incoming payload containing updates for a manual or
manual section, check if it already has an organisation specified in the
content store. If not, set the organisation to HMRC by default.

This change includes an update to the PublishingApiNotifier that allows client
code to specify whether a put_links update should take place as part of
the notify. This is useful when removing manuals/sections, a case when no links
update is required.

Trello: https://trello.com/c/6Owhx9Vn