### PR TITLE
Fix how we handle get_links result in LinksBuilder

### DIFF
--- a/app/models/links_builder.rb
+++ b/app/models/links_builder.rb
@@ -5,18 +5,15 @@ class LinksBuilder
   end
 
   def build_links
-    @content_store_links = get_links
+    @content_store_links = Services.publishing_api
+      .get_links(@content_id)
+      .try(:links)
+      .to_h.with_indifferent_access
     set_organistion
     @built_links
   end
 
 private
-  def get_links
-    Services.publishing_api.get_links(@content_id)
-  rescue GdsApi::HTTPNotFound
-    {}
-  end
-
   def set_organistion
     if @content_store_links["organisations"].present?
       @built_links["organisations"] = @content_store_links["organisations"]

--- a/spec/models/links_builder_spec.rb
+++ b/spec/models/links_builder_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 describe LinksBuilder do
+  include LinksUpdateHelper
+
   describe "#build_links" do
     let(:content_id) { "document-uuid" }
 
     context "document already has linked organisation" do
       before do
-        allow(Services.publishing_api).to receive(:get_links).with(content_id).and_return(
-          { "organisations" => ["some-org-uuid"] }
-        )
+        stub_publishing_api_get_links(content_id, body: { links: { "organisations" => ["some-org-uuid"] } })
       end
 
       it "uses the existing organisation content ID" do
@@ -20,9 +20,7 @@ describe LinksBuilder do
 
     context "document does not have linked organisation" do
       before do
-        allow(Services.publishing_api).to receive(:get_links).with(content_id).and_return(
-          {}
-        )
+        stub_publishing_api_get_links(content_id, body: { links: { "some_other_link" => "foo" } })
       end
 
       it "uses the default HMRC organisation content ID" do
@@ -32,9 +30,9 @@ describe LinksBuilder do
       end
     end
 
-    context "no document found" do
+    context "no links found" do
       before do
-        allow(Services.publishing_api).to receive(:get_links).with(content_id).and_raise(GdsApi::HTTPNotFound.new(404, 'some', 'error'))
+        allow(Services.publishing_api).to receive(:get_links).with(content_id).and_return(nil)
       end
 
       it "uses the default HMRC organisation content ID" do


### PR DESCRIPTION
Why?:

The existing code makes incorrect assumptions about the payload
returned by get_links in the PublishingApiV2 adapter, resulting in nil
errors when no link set is present on a given content item.

How?:

- Correctly account for the two possible results of this call to the
  adapter: a hash with a 'links' key or nil.
- Use the existing LinksUpdateHelper to stub out the resulting network call
  in a consistent manner.

Trello: https://trello.com/c/6Owhx9Vn