### PR TITLE
Remove unused add_organisations_to_details method

### DIFF
--- a/app/models/helpers/publishing_api_helpers.rb
+++ b/app/models/helpers/publishing_api_helpers.rb
@@ -1,18 +1,5 @@
 module Helpers
   module PublishingAPIHelpers
-    def add_organisations_to_details(attributes)
-      attributes["details"].merge!(
-        "organisations" => [
-          {
-            "title" => "HM Revenue & Customs",
-            "abbreviation" => "HMRC",
-            "web_url" => "https://www.gov.uk/government/organisations/hm-revenue-customs"
-          }
-        ]
-      )
-      attributes
-    end
-
     def add_absent_content_id(attributes)
       attributes["content_id"] = base_path_uuid unless attributes["content_id"]
       attributes


### PR DESCRIPTION
This stopped being called as part of 1422b548b2621b89d6b777bf58547fbe21f25c01, but was still present.  Remove it now that it's no longer used.