### PR TITLE
Revert change to a manual slug

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -60,7 +60,7 @@ KNOWN_MANUAL_SLUGS = %w{
   export-procedures
   film-production-company-manual
   fraud-civil-investigation
-  gas-road-fuel-use
+  gas-for-road-fuel-use
   general-insurance-manual
   guidance-real-estate-investment-trusts
   guidance-audit-customs-values


### PR DESCRIPTION
The manual is already [published at the old slug](https://www.gov.uk/hmrc-internal-manuals/gas-for-road-fuel-use), so will need more work than
this to change the slug. Reverting this change allows us to deploy the others
made in fde01a9dd06a937dceac808fefacb912cb260698 now.