### PR TITLE
Update link paths in docs for JSON schemas

### DIFF
--- a/docs/extended_documentation.md
+++ b/docs/extended_documentation.md
@@ -39,7 +39,7 @@ The `<slug>` is used as part of the GOV.UK URL for the document.
 
 ### JSON Schema
 
-[JSON Schema for manuals](public/manual-schema.json)
+[JSON Schema for manuals](/public/manual-schema.json)
 
 ## Adding or updating a manual section
 
@@ -58,7 +58,7 @@ The `<manual-slug>` and `<section_slug>` will be used as part of the GOV.UK URL 
 
 ### JSON Schema
 
-[JSON Schema for sections](public/section-schema.json)
+[JSON Schema for sections](/public/section-schema.json)
 
 ## Possible responses to PUT requests
 


### PR DESCRIPTION
The paths were not updated when the extended documentation was moved to the docs folder in https://github.com/alphagov/hmrc-manuals-api/commit/a439160d10cab98197da9a25adf1449e9a66048c, and therefore would 404.