### PR TITLE
Send manual & section content_id to Rummager

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -86,7 +86,7 @@ class PublishingAPIManual
   def save!
     raise ValidationError, "manual is invalid" unless valid?
     publishing_api_response = PublishingAPINotifier.new(self).notify
-    rummager_manual = RummagerManual.new(base_path, to_h)
+    rummager_manual = RummagerManual.new(base_path, to_h, content_id)
     rummager_manual.save!
     publishing_api_response
   end

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -76,7 +76,7 @@ class PublishingAPISection
   def save!
     raise ValidationError, "section is invalid" unless valid?
     publishing_api_response = PublishingAPINotifier.new(self).notify
-    rummager_section = RummagerSection.new(base_path, to_h)
+    rummager_section = RummagerSection.new(base_path, to_h, content_id)
     rummager_section.save!
 
     publishing_api_response

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -1,7 +1,8 @@
 class RummagerManual < RummagerBase
-  def initialize(base_path, publishing_api_manual_hash)
+  def initialize(base_path, publishing_api_manual_hash, content_id)
     @base_path = base_path
     @publishing_api_manual = publishing_api_manual_hash
+    @content_id = content_id
   end
 
   def id
@@ -10,6 +11,7 @@ class RummagerManual < RummagerBase
 
   def to_h
     data = {
+      'content_id'         => @content_id,
       'title'              => @publishing_api_manual['title'],
       'description'        => @publishing_api_manual['description'],
       'link'               => id,

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -10,7 +10,7 @@ class RummagerManual < RummagerBase
   end
 
   def to_h
-    data = {
+    {
       'content_id'         => @content_id,
       'title'              => @publishing_api_manual['title'],
       'description'        => @publishing_api_manual['description'],
@@ -21,8 +21,6 @@ class RummagerManual < RummagerBase
       'format'             => MANUAL_FORMAT,
       'latest_change_note' => latest_change_note,
     }
-
-    data
   end
 
   def save!

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -1,7 +1,8 @@
 class RummagerSection < RummagerBase
-  def initialize(base_path, publishing_api_section_hash)
+  def initialize(base_path, publishing_api_section_hash, content_id)
     @base_path = base_path
     @publishing_api_section = publishing_api_section_hash
+    @content_id = content_id
   end
 
   def id
@@ -22,6 +23,7 @@ class RummagerSection < RummagerBase
 
   def to_h
     {
+      'content_id'              => @content_id,
       'title'                   => title,
       'description'             => @publishing_api_section['description'],
       'link'                    => id,

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -1,6 +1,7 @@
 module RummagerHelpers
   def maximal_manual_for_rummager
     {
+      'content_id'         => '913fd52f-072c-409e-88b2-ea0b7a8b6d9c',
       'title'              => 'Employment Income Manual',
       'description'        => 'A manual about incoming employment',
       'link'               => '/hmrc-internal-manuals/employment-income-manual',
@@ -14,6 +15,7 @@ module RummagerHelpers
 
   def maximal_section_for_rummager
     {
+      'content_id'             => '25e687b8-74da-4892-938d-7de82fa5df27',
       'title'                  => '12345 - A section on a part of employment income',
       'description'            => 'Some description',
       'link'                   => '/hmrc-internal-manuals/employment-income-manual/12345',


### PR DESCRIPTION
The content_id is currently not in Rummager. To ease future development we'd like to start sending it, so we don't have to use the lookup endpoint in https://github.com/alphagov/rummager/pull/632 to find the item for a content_id.

Related PR: https://github.com/alphagov/whitehall/pull/2569