### PR TITLE
Add govuk linter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,14 +10,11 @@ gem 'gds-sso', '9.3.0'
 gem 'plek', '1.11.0'
 gem 'gds-api-adapters', '~> 26.5'
 gem 'govspeak', '3.0.0'
-
 gem 'sidekiq', '3.4.2'
-
 gem 'uuidtools', '2.1.5'
 
 group :development do
   gem "foreman", "0.78.0"
-  gem "govuk-lint"
 end
 
 group :development, :test do
@@ -25,6 +22,7 @@ group :development, :test do
   gem 'rspec-collection_matchers', '1.0.0'
   gem 'pry-byebug'
   gem 'shoulda-matchers', '~> 3.1'
+  gem "govuk-lint"
 end
 
 group :test do

--- a/app/models/publishing_api_redirected_section.rb
+++ b/app/models/publishing_api_redirected_section.rb
@@ -9,11 +9,11 @@ class PublishingAPIRedirectedSection
   validates_with InContentStoreValidator,
     format: SECTION_FORMAT,
     content_store: Services.content_store,
-    unless: -> { 
+    unless: -> {
       errors[:manual_slug].present? ||
-      errors[:section_slug].present? ||
-      errors[:destination_manual_slug].present? ||
-      errors[:destination_section_slug].present?
+        errors[:section_slug].present? ||
+        errors[:destination_manual_slug].present? ||
+        errors[:destination_section_slug].present?
     }
 
   attr_accessor :manual_slug, :section_slug, :destination_manual_slug, :destination_section_slug

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -35,7 +35,7 @@ class PublishingAPISection
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_breadcrumbs(enriched_data)
-      enriched_data = add_base_path_to_manual(enriched_data)
+      add_base_path_to_manual(enriched_data)
     end
   end
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -50,6 +50,17 @@ git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-sc
 export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
+
+# Lint changes introduced in this branch, but not for master
+if [[ ${GIT_BRANCH} != "origin/master" ]]; then
+  bundle exec govuk-lint-ruby \
+  --diff \
+  --cached \
+  --format html --out rubocop-${GIT_COMMIT}.html \
+  --format clang \
+  app spec lib
+fi
+
 RAILS_ENV=test bundle exec rake ci:setup:rspec ${TEST_TASK:-"default"}
 
 EXIT_STATUS=$?

--- a/lib/struct_with_rendered_markdown.rb
+++ b/lib/struct_with_rendered_markdown.rb
@@ -1,7 +1,7 @@
 require 'kramdown'
 
 class StructWithRenderedMarkdown
-  ATTRIBUTES_THAT_CAN_CONTAIN_MARKDOWN = [ "body" ]
+  ATTRIBUTES_THAT_CAN_CONTAIN_MARKDOWN = ["body"]
 
   def initialize(struct)
     @struct = struct.dup
@@ -19,7 +19,7 @@ private
       struct.each do |key, value|
         if ATTRIBUTES_THAT_CAN_CONTAIN_MARKDOWN.include?(key)
           struct[key] = markdown_to_html(value)
-        elsif value.is_a?(Hash) or value.is_a?(Array)
+        elsif value.is_a?(Hash) || value.is_a?(Array)
           render_markdown_in(value)
         end
       end

--- a/lib/structured_data.rb
+++ b/lib/structured_data.rb
@@ -19,7 +19,7 @@ class StructuredData
         find_string_fields_in(value, "#{path}[#{index}]")
       end
     when String then
-      [ path: path, value: struct ]
+      [path: path, value: struct]
     else
       []
     end

--- a/lib/tasks/ci_reporter.rake
+++ b/lib/tasks/ci_reporter.rake
@@ -1,3 +1,1 @@
-if Rails.env.development? or Rails.env.test?
-  require 'ci/reporter/rake/rspec'
-end
+require 'ci/reporter/rake/rspec' if Rails.env.development? || Rails.env.test?

--- a/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
@@ -1,7 +1,6 @@
 require 'gds_api/rummager'
 
 namespace :rummager_republish do
-
   # Use lambdas because methods in Rake tasks are global, which could
   # cause problems if anyone else were to write more Rake tasks in this
   # app.
@@ -16,7 +15,7 @@ namespace :rummager_republish do
     }
 
     section_data = {
-      'title'             => title_without_section_ids.call(section['title'],section['hmrc_manual_section_id']),
+      'title'             => title_without_section_ids.call(section['title'], section['hmrc_manual_section_id']),
       'description'       => section['description'],
       'public_updated_at' => section['public_timestamp'],
       'details'           => details_hash,

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -68,7 +68,6 @@ describe PublishingAPIManual do
 
   describe 'content_id' do
     context 'when content id is specified in the attributes' do
-
       let(:content_id) { SecureRandom.uuid }
       let(:attributes) { valid_manual.merge("content_id" => content_id) }
 
@@ -112,7 +111,7 @@ describe PublishingAPIManual do
 
     context "with invalid child section groups" do
       let(:child_section_group_with_dangerous_title) { { "title" => "title <script></script>", "child_sections" => [] } }
-      let(:attributes) { valid_manual("details" => { "child_section_groups" => [ child_section_group_with_dangerous_title ] * 2 }) }
+      let(:attributes) { valid_manual("details" => { "child_section_groups" => [child_section_group_with_dangerous_title] * 2 }) }
 
       it "is invalid" do
         expect(subject).to_not be_valid

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -10,14 +10,14 @@ describe PublishingAPIRedirectedSection do
     let(:destination_manual_slug) { "redirect-manual" }
     let(:destination_section_slug) { "redirect-section" }
     subject(:redirected_manual) { described_class.new(manual_slug, section_slug, destination_manual_slug, destination_section_slug) }
-    
+
     context 'validating slug format' do
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:manual_slug) }
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:section_slug) }
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:destination_manual_slug) }
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:destination_section_slug) }
     end
-    
+
     context 'checking that the manual section exists already' do
       include GdsApi::TestHelpers::ContentStore
       let(:section_path) { subject.base_path }

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -68,7 +68,6 @@ describe PublishingAPIRemovedManual do
     it 'includes the updates_path of the manual as an exact path in routes' do
       expect(subject[:routes]).to include({ path: removed_manual.updates_path, type: :exact })
     end
-
   end
 
   describe '#sections' do

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -31,7 +31,7 @@ describe PublishingAPIRemovedSection do
     let(:manual_slug) { 'a-manual' }
     let(:section_slug) { 'a-section' }
     subject(:removed_manual) { described_class.new(manual_slug, section_slug) }
-    
+
     context 'validating slug format' do
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:manual_slug) }
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:section_slug) }

--- a/spec/models/structured_data_spec.rb
+++ b/spec/models/structured_data_spec.rb
@@ -15,8 +15,8 @@ describe StructuredData do
   end
 
   it "finds string fields in arrays" do
-    expect(data(a: 1, b: [ { c: "abc" }, { d: "xyz" } ]).string_fields).to eq(
-      [ { path: "#/b[0]/c", value: "abc" }, { path: "#/b[1]/d", value: "xyz" } ]
+    expect(data(a: 1, b: [{ c: "abc" }, { d: "xyz" }]).string_fields).to eq(
+      [{ path: "#/b[0]/c", value: "abc" }, { path: "#/b[1]/d", value: "xyz" }]
     )
   end
 end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -13,7 +13,7 @@ describe PublishingAPINotifier do
     end
     let(:successful_response) { double "response", version: 33 }
 
-    it "makes calls to update the document, publish it, and update its links via the publishing API"   do
+    it "makes calls to update the document, publish it, and update its links via the publishing API" do
       expect(Services.publishing_api).to receive(:put_content).with(content_id, document_hash)
         .and_return(successful_response)
       expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', {previous_version: 33})

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Style/SymbolProc
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 ENV['GOVUK_WEBSITE_ROOT'] ||= 'https://www.gov.uk'
@@ -43,3 +45,5 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 end
+
+# rubocop:enable Style/SymbolProc

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -37,7 +37,7 @@ describe "validation" do
       expect(response.status).to eq(422)
       expect(json_response).to include("status" => "error")
       expect(json_response["errors"].first).to match(
-        "does not match any of the following valid slugs: #{ KNOWN_MANUAL_SLUGS.join(" ") }"
+        "does not match any of the following valid slugs: #{KNOWN_MANUAL_SLUGS.join(' ')}"
       )
     end
 
@@ -100,7 +100,7 @@ describe "validation" do
 
       expect(response.status).to eq(422)
       expect(json_response).to include("status" => "error")
-      expect(json_response["errors"].first).to match("does not match any of the following valid slugs: #{ KNOWN_MANUAL_SLUGS.join(" ") }")
+      expect(json_response["errors"].first).to match("does not match any of the following valid slugs: #{KNOWN_MANUAL_SLUGS.join(' ')}")
     end
   end
 end

--- a/spec/support/ignoring_errors.rb
+++ b/spec/support/ignoring_errors.rb
@@ -2,8 +2,8 @@ module IgnoringError
   def ignoring_error(error_class, &block)
     block.call
   rescue error_class
+    nil
   end
-
 end
 
 RSpec.configuration.include IgnoringError

--- a/spec/support/json_request_helpers.rb
+++ b/spec/support/json_request_helpers.rb
@@ -13,4 +13,4 @@ module JSONRequestHelper
   end
 end
 
-RSpec.configuration.include JSONRequestHelper, :type => :request
+RSpec.configuration.include JSONRequestHelper, type: :request


### PR DESCRIPTION
We add the linter to jenkins.sh and fix all style violations except one. We ignore the SymbolProc style suggestion for rails_helper.rb, as it would go against convention of what people expect this file to look like. See commit for details.