### PR TITLE
Remove organisation link from Rummager payload

### DIFF
--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -16,7 +16,6 @@ class RummagerManual < RummagerBase
       'description'        => @publishing_api_manual['description'],
       'link'               => id,
       'indexable_content'  => nil,
-      'organisations'      => [GOVUK_HMRC_SLUG],
       'public_timestamp'   => @publishing_api_manual['public_updated_at'],
       'format'             => MANUAL_FORMAT,
       'latest_change_note' => latest_change_note,

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -28,7 +28,6 @@ class RummagerSection < RummagerBase
       'description'             => @publishing_api_section['description'],
       'link'                    => id,
       'indexable_content'       => body_without_html,
-      'organisations'           => [GOVUK_HMRC_SLUG],
       'public_timestamp'        => @publishing_api_section['public_updated_at'],
       'hmrc_manual_section_id'  => section_id,
       'manual'                  => @publishing_api_section['details']['manual']['base_path'],

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -6,7 +6,6 @@ module RummagerHelpers
       'description'        => 'A manual about incoming employment',
       'link'               => '/hmrc-internal-manuals/employment-income-manual',
       'indexable_content'  => nil,
-      'organisations'      => ['hm-revenue-customs'],
       'public_timestamp'   => '2014-01-23T00:00:00+01:00',
       'format'             => 'hmrc_manual',
       'latest_change_note' => 'Description of changes in Title of a Section that was changed'
@@ -20,7 +19,6 @@ module RummagerHelpers
       'description'            => 'Some description',
       'link'                   => '/hmrc-internal-manuals/employment-income-manual/12345',
       'indexable_content'      => 'I need somebody to love', # Markdown/HTML has been stripped
-      'organisations'          => ['hm-revenue-customs'],
       'public_timestamp'       => '2014-01-23T00:00:00+01:00',
       'hmrc_manual_section_id' => '12345',
       'manual'                 => '/hmrc-internal-manuals/employment-income-manual',


### PR DESCRIPTION
Merge when we've switched on Rummager's publishing API fetch.

Why?:

Rummager has recently been updated to fetch links data directly from the
publishing API when indexing a document. Setting Rummager links data in
the publishing app is therefore redundant.

How?:

- Strip organisations from the payload in RummagerManual.
- Strip organisations from the payload in RummagerSection.