### PR TITLE
Use `document_type` and `schema_name`

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -25,7 +25,8 @@ class PublishingAPIManual
     @_to_h ||= begin
       enriched_data = @manual_attributes.except('content_id', 'update_type').deep_dup.merge({
         base_path: base_path,
-        format: MANUAL_FORMAT,
+        document_type: MANUAL_FORMAT,
+        schema_name: MANUAL_FORMAT,
         publishing_app: 'hmrc-manuals-api',
         rendering_app: 'manuals-frontend',
         routes: [

--- a/app/models/publishing_api_redirected_section.rb
+++ b/app/models/publishing_api_redirected_section.rb
@@ -27,7 +27,8 @@ class PublishingAPIRedirectedSection
 
   def to_h
     @_to_h ||= {
-      format: 'redirect',
+      document_type: 'redirect',
+      schema_name: 'redirect',
       publishing_app: 'hmrc-manuals-api',
       base_path: base_path,
       redirects: [

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -32,7 +32,8 @@ class PublishingAPIRemovedManual
   def to_h
     @_to_h ||= {
       base_path: base_path,
-      format: 'gone',
+      document_type: 'gone',
+      schema_name: 'gone',
       publishing_app: 'hmrc-manuals-api',
       update_type: update_type,
       routes: [

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -27,7 +27,8 @@ class PublishingAPIRemovedSection
   def to_h
     @_to_h ||= {
       base_path: base_path,
-      format: 'gone',
+      document_type: 'gone',
+      schema_name: 'gone',
       publishing_app: 'hmrc-manuals-api',
       update_type: update_type,
       routes: [

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -26,7 +26,8 @@ class PublishingAPISection
     @_to_h ||= begin
       enriched_data = @section_attributes.except('content_id', 'update_type').deep_dup.merge({
         base_path: base_path,
-        format: SECTION_FORMAT,
+        document_type: SECTION_FORMAT,
+        schema_name: SECTION_FORMAT,
         publishing_app: 'hmrc-manuals-api',
         rendering_app: 'manuals-frontend',
         routes: [{ path: PublishingAPISection.base_path(@manual_slug, @section_slug), type: :exact }],

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -54,8 +54,8 @@ describe PublishingAPIRedirectedSection do
       it { should be_valid_against_schema('redirect') }
     end
 
-    it 'is a "redirect" format object' do
-      expect(subject[:format]).to eq('redirect')
+    it 'is a "redirect" document type' do
+      expect(subject[:document_type]).to eq('redirect')
     end
 
     it 'is published by the "hmrc-manuals-api" app' do

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -49,8 +49,8 @@ describe PublishingAPIRemovedManual do
       it { should be_valid_against_schema('gone') }
     end
 
-    it 'is a "gone" format object' do
-      expect(subject[:format]).to eq('gone')
+    it 'is a "gone" document type' do
+      expect(subject[:document_type]).to eq('gone')
     end
 
     it 'is published by the "hmrc-manuals-api" app' do

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -74,8 +74,8 @@ describe PublishingAPIRemovedSection do
       it { should be_valid_against_schema('gone') }
     end
 
-    it 'is a "gone" format object' do
-      expect(subject[:format]).to eq('gone')
+    it 'is a "gone" document type' do
+      expect(subject[:document_type]).to eq('gone')
     end
 
     it 'is published by the "hmrc-manuals-api" app' do

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -3,7 +3,8 @@ module PublishingApiDataHelpers
     {
       "base_path" => "/hmrc-internal-manuals/employment-income-manual",
       "locale" => "en",
-      "format" => "hmrc_manual",
+      "document_type" => "hmrc_manual",
+      "schema_name" => "hmrc_manual",
       "title" => "Employment Income Manual",
       "description" => "A manual about incoming employment",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",
@@ -60,7 +61,8 @@ module PublishingApiDataHelpers
   def maximal_section_for_publishing_api(options = {})
     {
       "base_path" => "/hmrc-internal-manuals/employment-income-manual/12345",
-      "format" => "hmrc_manual_section",
+      "document_type" => "hmrc_manual_section",
+      "schema_name" => "hmrc_manual_section",
       "locale" => "en",
       "title" => "A section on a part of employment income",
       "description" => "Some description",
@@ -105,7 +107,8 @@ module PublishingApiDataHelpers
   def gone_manual_for_publishing_api(base_path: '/hmrc-internal-manuals/some-slug')
     {
       'base_path' => base_path,
-      'format' => 'gone',
+      'document_type' => 'gone',
+      'schema_name' => 'gone',
       'update_type' => 'major',
       'publishing_app' => 'hmrc-manuals-api',
       'routes' => [
@@ -124,7 +127,8 @@ module PublishingApiDataHelpers
   def gone_manual_section_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section')
     {
       'base_path' => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
-      'format' => 'gone',
+      'document_type' => 'gone',
+      'schema_name' => 'gone',
       'update_type' => 'major',
       'publishing_app' => 'hmrc-manuals-api',
       'routes' => [
@@ -138,7 +142,8 @@ module PublishingApiDataHelpers
 
   def redirected_manual_section_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section', dest_manual_slug: 'some-other-manual', dest_section_slug: 'some-other-section')
     {
-      'format' => 'redirect',
+      'document_type' => 'redirect',
+      'schema_name' => 'redirect',
       'publishing_app' => 'hmrc-manuals-api',
       'base_path' => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
       'redirects' => [


### PR DESCRIPTION
`document_type` and `schema_name` have replaced `format`.

Related: https://github.com/alphagov/govuk-content-schemas/pull/348