### PR TITLE
Change all instances of unified_search to search

### DIFF
--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -25,7 +25,7 @@ class PublishingAPIRemovedManual
 
   def sections_from_rummager
     query = RummagerSection.search_query(base_path)
-    Services.rummager.unified_search(query).results
+    Services.rummager.search(query).results
   end
   private :sections_from_rummager
 

--- a/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
+++ b/lib/tasks/rummager_republish/fix_leading_slashes_in_manual_keys_for_sections.rake
@@ -29,7 +29,7 @@ namespace :rummager_republish do
     # As of 2015-09-17, there are 2345 HMRC manual sections.
     count = 3000
 
-    search_results = rummager.unified_search(filter_format: ['hmrc_manual_section'],
+    search_results = rummager.search(filter_format: ['hmrc_manual_section'],
                                              count: count.to_s,
                                              fields: 'title,description,link,indexable_content,public_timestamp,hmrc_manual_section_id,manual')
 

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -74,7 +74,7 @@ describe PublishingAPIRemovedManual do
     subject(:removed_manual) { described_class.new('some-manual-slug') }
 
     it 'asks rummager for all the hmrc manual sections under its slug' do
-      rummager_query = stub_request(:get, %r{/unified_search.json})
+      rummager_query = stub_request(:get, %r{/search.json})
         .with(query: search_for_sections_rummager_query('some-manual-slug'))
         .to_return(body: no_manual_sections_rummager_json_result)
 
@@ -84,7 +84,7 @@ describe PublishingAPIRemovedManual do
     end
 
     it 'exposes each result from rummager as a PublishingAPIRemovedSection' do
-      stub_request(:get, %r{/unified_search.json})
+      stub_request(:get, %r{/search.json})
         .to_return(body: two_manual_sections_rummager_json_result('some-manual-slug'))
 
       sections = subject.sections
@@ -100,7 +100,7 @@ describe PublishingAPIRemovedManual do
     end
 
     it 'exposes the error from rummager if the rummager call fails' do
-      stub_request(:get, %r{/unified_search.json})
+      stub_request(:get, %r{/search.json})
         .to_return(status: 503, body: '{"error":"arg!"}')
 
       expect {


### PR DESCRIPTION
This commit changes all instances of unified_search to search when using the GDS API Adapters to access rummager. This provides consistency between the internal and external APIs in terms of naming.

Follow-up to https://github.com/alphagov/hmrc-manuals-api/pull/154

Trello: https://trello.com/c/cj8UX2jX