### PR TITLE
Add Lint to default rake task and fix deprecation warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+task default: [:lint]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from GdsApi::BaseError do |exception|
     notify_airbrake(exception)
-    if (exception.is_a?(GdsApi::HTTPErrorResponse) && (500..599).include?(exception.code)) ||
+    if (exception.is_a?(GdsApi::HTTPErrorResponse) && (500..599).cover?(exception.code)) ||
         exception.is_a?(GdsApi::TimedOutException)
       message = 'Service unavailable'
       render json: { status: "error", errors: [message] }, status: 503
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
   def parse_request_body
     @parsed_request_body = JSON.parse(request.body.read)
   rescue JSON::ParserError => e

--- a/app/models/links_builder.rb
+++ b/app/models/links_builder.rb
@@ -14,12 +14,13 @@ class LinksBuilder
   end
 
 private
+
   def set_organisation
-    if @content_store_links["organisations"].present?
-      @built_links["organisations"] = @content_store_links["organisations"]
-    else
-      # Use HMRC content ID to set organisation
-      @built_links["organisations"] = ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
-    end
+    @built_links["organisations"] = if @content_store_links["organisations"].present?
+                                      @content_store_links["organisations"]
+                                    else
+                                      # Use HMRC content ID to set organisation
+                                      ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+                                    end
   end
 end

--- a/app/models/links_builder.rb
+++ b/app/models/links_builder.rb
@@ -9,12 +9,12 @@ class LinksBuilder
       .get_links(@content_id)
       .try(:links)
       .to_h.with_indifferent_access
-    set_organistion
+    set_organisation
     @built_links
   end
 
 private
-  def set_organistion
+  def set_organisation
     if @content_store_links["organisations"].present?
       @built_links["organisations"] = @content_store_links["organisations"]
     else

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -23,8 +23,7 @@ class PublishingAPIManual
 
   def to_h
     @_to_h ||= begin
-      enriched_data = @manual_attributes.except('content_id', 'update_type').deep_dup.merge({
-        base_path: base_path,
+      enriched_data = @manual_attributes.except('content_id', 'update_type').deep_dup.merge(base_path: base_path,
         document_type: MANUAL_FORMAT,
         schema_name: MANUAL_FORMAT,
         publishing_app: 'hmrc-manuals-api',
@@ -33,8 +32,7 @@ class PublishingAPIManual
           { path: base_path, type: :exact },
           { path: updates_path, type: :exact }
         ],
-        locale: "en",
-      })
+        locale: "en")
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_change_notes(enriched_data)
@@ -62,7 +60,7 @@ class PublishingAPIManual
     PublishingAPIManual.base_path(@slug)
   end
 
-  BASE_PATH_SEGMENT = 'hmrc-internal-manuals'
+  BASE_PATH_SEGMENT = 'hmrc-internal-manuals'.freeze
 
   def self.base_path(manual_slug)
     # The slug should be lowercase, but let's make sure
@@ -93,6 +91,7 @@ class PublishingAPIManual
   end
 
 private
+
   def generate_content_id_if_absent
     @manual_attributes["content_id"] = base_path_uuid unless @manual_attributes["content_id"]
   end
@@ -115,7 +114,7 @@ private
 
   def incoming_manual_is_valid
     unless @manual.valid?
-      @manual.errors.full_messages.each {|message| self.errors[:base] << message }
+      @manual.errors.full_messages.each { |message| self.errors[:base] << message }
     end
   end
 

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -24,15 +24,13 @@ class PublishingAPISection
 
   def to_h
     @_to_h ||= begin
-      enriched_data = @section_attributes.except('content_id', 'update_type').deep_dup.merge({
-        base_path: base_path,
+      enriched_data = @section_attributes.except('content_id', 'update_type').deep_dup.merge(base_path: base_path,
         document_type: SECTION_FORMAT,
         schema_name: SECTION_FORMAT,
         publishing_app: 'hmrc-manuals-api',
         rendering_app: 'manuals-frontend',
         routes: [{ path: PublishingAPISection.base_path(@manual_slug, @section_slug), type: :exact }],
-        locale: "en",
-      })
+        locale: "en")
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_breadcrumbs(enriched_data)
@@ -84,6 +82,7 @@ class PublishingAPISection
   end
 
 private
+
   def generate_content_id_if_absent
     if @section_attributes.is_a?(Hash)
       @section_attributes["content_id"] = base_path_uuid unless @section_attributes["content_id"]
@@ -117,12 +116,12 @@ private
 
   def incoming_section_is_valid
     unless @section.valid?
-      @section.errors.full_messages.each {|message| self.errors[:base] << message }
+      @section.errors.full_messages.each { |message| self.errors[:base] << message }
     end
   end
 
   def section_slug_matches_section_id
-    if section_slug.to_s.downcase != section_attributes['details']['section_id'].downcase
+    if !section_slug.to_s.casecmp(section_attributes['details']['section_id'].downcase).zero?
       errors[:base] << "Slug in URL and Section ID must match, ignoring case"
     end
   end

--- a/app/models/rummager_base.rb
+++ b/app/models/rummager_base.rb
@@ -1,3 +1,3 @@
 class RummagerBase
-  GOVUK_HMRC_SLUG = 'hm-revenue-customs'
+  GOVUK_HMRC_SLUG = 'hm-revenue-customs'.freeze
 end

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -27,6 +27,7 @@ class RummagerManual < RummagerBase
   end
 
 private
+
   def latest_change_note
     latest = @publishing_api_manual['details'].fetch('change_notes', []).first
 

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -11,6 +11,7 @@ class PublishingAPINotifier
   end
 
 private
+
   def put_content_item
     Services.publishing_api.put_content(@document.content_id, @document.to_h)
   end

--- a/app/validators/conforms_to_json_schema_validator.rb
+++ b/app/validators/conforms_to_json_schema_validator.rb
@@ -7,6 +7,6 @@ class ConformsToJsonSchemaValidator < ActiveModel::EachValidator
 
   def validate_each(record, _attribute, value)
     errors = JSON::Validator.fully_validate(@schema, value, validate_schema: true)
-    errors.each {|e| record.errors[:base] << e }
+    errors.each { |e| record.errors[:base] << e }
   end
 end

--- a/app/validators/in_content_store_validator.rb
+++ b/app/validators/in_content_store_validator.rb
@@ -14,12 +14,13 @@ class InContentStoreValidator < ActiveModel::Validator
       record.errors.add(:base, wrong_format_message(record, content_item))
     end
   rescue GdsApi::HTTPNotFound
-      record.errors.add(:base, missing_message(record, content_item))
+    record.errors.add(:base, missing_message(record, content_item))
   rescue GdsApi::HTTPGone
-      record.errors.add(:base, gone_message(record, content_item))
+    record.errors.add(:base, gone_message(record, content_item))
   end
 
-  private
+private
+
   def fetch_content_item(record)
     content_store.content_item(record.base_path)
   end

--- a/app/validators/in_content_store_validator.rb
+++ b/app/validators/in_content_store_validator.rb
@@ -10,13 +10,13 @@ class InContentStoreValidator < ActiveModel::Validator
 
   def validate(record)
     content_item = fetch_content_item(record)
-    if content_item.nil?
-      record.errors.add(:base, missing_message(record, content_item))
-    elsif content_item.format == 'gone'
-      record.errors.add(:base, gone_message(record, content_item))
-    elsif content_item.format != format
+    if content_item.format != format
       record.errors.add(:base, wrong_format_message(record, content_item))
     end
+  rescue GdsApi::HTTPNotFound
+      record.errors.add(:base, missing_message(record, content_item))
+  rescue GdsApi::HTTPGone
+      record.errors.add(:base, gone_message(record, content_item))
   end
 
   private

--- a/app/validators/no_dangerous_html_in_text_fields_validator.rb
+++ b/app/validators/no_dangerous_html_in_text_fields_validator.rb
@@ -11,7 +11,7 @@ class NoDangerousHTMLInTextFieldsValidator < ActiveModel::EachValidator
     'www.gov.uk',
     'assets.digital.cabinet-office.gov.uk',
     'assets.publishing.service.gov.uk',
-  ]
+  ].freeze
 
   def validate_each(record, _attribute, value)
     freetext_fields_with_paths = StructuredData.new(value).string_fields
@@ -26,6 +26,7 @@ class NoDangerousHTMLInTextFieldsValidator < ActiveModel::EachValidator
   end
 
 private
+
   def dangerous?(value)
     validator = Govspeak::HtmlValidator.new(value, allowed_image_hosts: ALLOWED_IMAGE_HOSTS)
     validator.invalid?

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,1 @@
+GdsApi.config.always_raise_for_not_found = true

--- a/lib/sections_checker.rb
+++ b/lib/sections_checker.rb
@@ -55,10 +55,9 @@ private
 
   def child_section_in_tree?(parent, child)
     child_sections(parent).each do |child_section|
-      if child_section['base_path'] == child['base_path']
+      if child_section['base_path'] == child['base_path'] ||
+          child_section_in_tree?(content_item(child_section['base_path']), child)
         return true
-      else
-        return true if child_section_in_tree?(content_item(child_section['base_path']), child)
       end
     end
     false

--- a/lib/struct_with_rendered_markdown.rb
+++ b/lib/struct_with_rendered_markdown.rb
@@ -1,7 +1,7 @@
 require 'kramdown'
 
 class StructWithRenderedMarkdown
-  ATTRIBUTES_THAT_CAN_CONTAIN_MARKDOWN = ["body"]
+  ATTRIBUTES_THAT_CAN_CONTAIN_MARKDOWN = ["body"].freeze
 
   def initialize(struct)
     @struct = struct.dup
@@ -12,6 +12,7 @@ class StructWithRenderedMarkdown
   end
 
 private
+
   def render_markdown_in(struct)
     if struct.is_a?(Array)
       struct.each { |item| render_markdown_in(item) }

--- a/lib/structured_data.rb
+++ b/lib/structured_data.rb
@@ -7,7 +7,8 @@ class StructuredData
     find_string_fields_in(@struct, "#")
   end
 
-  private
+private
+
   def find_string_fields_in(struct, path)
     case struct
     when Hash then

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --format clang app spec lib"
+end

--- a/spec/lib/sections_checker_spec.rb
+++ b/spec/lib/sections_checker_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe SectionsChecker do
     )
   end
 
-  def hmrc_manual_section_content_item_for_base_path(base_path, child_section_groups:[], breadcrumbs: [], manual_base_path:)
+  def hmrc_manual_section_content_item_for_base_path(base_path, child_section_groups:[], breadcrumbs:[], manual_base_path: "")
     item = content_item_for_base_path(base_path)
     item.merge(
       "format" => SECTION_FORMAT,

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -92,13 +92,13 @@ describe PublishingAPIRedirectedSection do
       subject(:redirected_manual_section) { described_class.new('some-manual', 'some-section', 'some-other-manual', 'some-other-section') }
 
       it 'issues put_content and publish requests to the publishing api to mark the manual section as gone' do
-        stub_publishing_api_put_content(redirected_manual_section.content_id, {}, { body: {version: 33} })
-        stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33}.to_json)
+        stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
+        stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
 
         subject.save!
 
         assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_for_publishing_api)
-        assert_publishing_api_publish(redirected_manual_section.content_id, {update_type: redirected_manual_section.update_type, previous_version: 33})
+        assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
       end
     end
   end

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -62,11 +62,11 @@ describe PublishingAPIRemovedManual do
     end
 
     it 'includes the base_path of the manual as an exact path in routes' do
-      expect(subject[:routes]).to include({ path: removed_manual.base_path, type: :exact })
+      expect(subject[:routes]).to include(path: removed_manual.base_path, type: :exact)
     end
 
     it 'includes the updates_path of the manual as an exact path in routes' do
-      expect(subject[:routes]).to include({ path: removed_manual.updates_path, type: :exact })
+      expect(subject[:routes]).to include(path: removed_manual.updates_path, type: :exact)
     end
   end
 
@@ -142,14 +142,14 @@ describe PublishingAPIRemovedManual do
       let(:gone_manual) { gone_manual_for_publishing_api(base_path: publishing_api_base_path) }
 
       it 'issues a put_content and publish requests to the publishing api to mark the manual as gone' do
-        stub_publishing_api_put_content(removed_manual.content_id, {}, {status: 201, body: {version: 4}.to_json})
-        stub_publishing_api_publish(removed_manual.content_id, { update_type: 'major', previous_version: 4}.to_json)
+        stub_publishing_api_put_content(removed_manual.content_id, {}, status: 201, body: { version: 4 }.to_json)
+        stub_publishing_api_publish(removed_manual.content_id, { update_type: 'major', previous_version: 4 }.to_json)
         stub_any_rummager_delete
 
         subject.save!
 
         assert_publishing_api_put_content(removed_manual.content_id, gone_manual)
-        assert_publishing_api_publish(removed_manual.content_id, {update_type: 'major', previous_version: 4})
+        assert_publishing_api_publish(removed_manual.content_id, update_type: 'major', previous_version: 4)
 
         #TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`
         #      once https://github.com/alphagov/gds-api-adapters/pull/362 has been merged

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -87,7 +87,7 @@ describe PublishingAPIRemovedSection do
     end
 
     it 'includes the base_path of the manual section as an exact path in routes' do
-      expect(subject[:routes]).to include({ path: removed_manual_section.base_path, type: :exact })
+      expect(subject[:routes]).to include(path: removed_manual_section.base_path, type: :exact)
     end
   end
 
@@ -123,8 +123,8 @@ describe PublishingAPIRemovedSection do
       let(:publishing_api_base_path) { '/hmrc-internal-manuals/some-manual/some-section' }
 
       it 'issues put_content and publish requests to the publishing api to mark the manual section as gone' do
-        stub_publishing_api_put_content(removed_manual_section.content_id, {}, { body: {version: 33} })
-        stub_publishing_api_publish(removed_manual_section.content_id, { update_type: 'major', previous_version: 33}.to_json)
+        stub_publishing_api_put_content(removed_manual_section.content_id, {}, body: { version: 33 })
+        stub_publishing_api_publish(removed_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
         stub_any_rummager_delete
 
         subject.save!
@@ -132,7 +132,7 @@ describe PublishingAPIRemovedSection do
         assert_publishing_api_put_content(removed_manual_section.content_id, gone_manual_section_for_publishing_api)
         assert_publishing_api_publish(
           removed_manual_section.content_id,
-          {update_type: removed_manual_section.update_type, previous_version: 33}
+          update_type: removed_manual_section.update_type, previous_version: 33
         )
 
         # TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -84,7 +84,7 @@ describe PublishingAPISection do
   describe 'content_id' do
     context 'when content id is present' do
       let(:content_id) { SecureRandom.uuid }
-      let(:attributes) {valid_section.merge("content_id" => content_id) }
+      let(:attributes) { valid_section.merge("content_id" => content_id) }
 
       it 'returns the context id' do
         expect(subject.content_id).to eq content_id
@@ -111,7 +111,7 @@ describe PublishingAPISection do
     context 'mismatched section ID and slug' do
       subject { PublishingAPISection.new('manual', 'mismatch', valid_section) }
 
-      it { should_not be_valid}
+      it { should_not be_valid }
 
       it 'rejects mismatches' do
         subject.valid? # trigger validations and populate errors

--- a/spec/models/structured_data_spec.rb
+++ b/spec/models/structured_data_spec.rb
@@ -11,7 +11,7 @@ describe StructuredData do
   end
 
   it "finds nested string fields" do
-    expect(data(a: 1, b: { c: "abc"}).string_fields).to eq([path: "#/b/c", value: "abc"])
+    expect(data(a: 1, b: { c: "abc" }).string_fields).to eq([path: "#/b/c", value: "abc"])
   end
 
   it "finds string fields in arrays" do

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -3,21 +3,21 @@ require 'rails_helper'
 describe PublishingAPINotifier do
   describe '#notify' do
     let(:content_id) { 'de305d54-75b4-431b-adb2-eb6b9e546014' }
-    let(:document_hash) { {'a' => '1'} }
+    let(:document_hash) { { 'a' => '1' } }
     let(:document) do
       double PublishingAPIManual,
         content_id: content_id,
         to_h: document_hash,
         update_type: 'major',
-        links: { 'some' => 'linked_data'}
+        links: { 'some' => 'linked_data' }
     end
     let(:successful_response) { double "response", version: 33 }
 
     it "makes calls to update the document, publish it, and update its links via the publishing API" do
       expect(Services.publishing_api).to receive(:put_content).with(content_id, document_hash)
         .and_return(successful_response)
-      expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', {previous_version: 33})
-      expect(Services.publishing_api).to receive(:patch_links).with(content_id, links: { 'some' => 'linked_data'})
+      expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', previous_version: 33)
+      expect(Services.publishing_api).to receive(:patch_links).with(content_id, links: { 'some' => 'linked_data' })
 
       PublishingAPINotifier.new(document).notify
     end
@@ -26,7 +26,7 @@ describe PublishingAPINotifier do
       it "updates and publishes the document, but doesn't update the links" do
         expect(Services.publishing_api).to receive(:put_content).with(content_id, document_hash)
           .and_return(successful_response)
-        expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', {previous_version: 33})
+        expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', previous_version: 33)
         expect(Services.publishing_api).to_not receive(:patch_links)
 
         PublishingAPINotifier.new(document).notify(update_links: false)

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'authentication' do
   it 'reject the request if no bearer token is present' do
-    put_json '/hmrc-manuals/imaginary-slug', valid_manual, { "HTTP_AUTHORIZATION" => "" }
+    put_json '/hmrc-manuals/imaginary-slug', valid_manual, "HTTP_AUTHORIZATION" => ""
 
     expect(response.status).to eq(401)
   end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -12,8 +12,8 @@ describe 'manual sections resource' do
   }
 
   it 'confirms update of the manual section' do
-    stub_publishing_api_put_content(maximal_section_content_id, {}, { body: {version: 788} })
-    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788}.to_json)
+    stub_publishing_api_put_content(maximal_section_content_id, {}, body: { version: 788 })
+    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788 }.to_json)
     stub_any_rummager_post
     stub_publishing_api_get_links(maximal_section_content_id)
     stub_put_default_organisation(maximal_section_content_id)
@@ -29,28 +29,24 @@ describe 'manual sections resource' do
   end
 
   it 'errors if the Accept header is not application/json' do
-    stub_publishing_api_put_content(maximal_section_content_id, {}, { body: {version: 12} })
-    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 12}.to_json)
+    stub_publishing_api_put_content(maximal_section_content_id, {}, body: { version: 12 })
+    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 12 }.to_json)
     stub_any_rummager_post
     stub_publishing_api_get_links(maximal_section_content_id)
     stub_put_default_organisation(maximal_section_content_id)
 
-    put maximal_section_endpoint, maximal_section.to_json, {
-      'CONTENT_TYPE' => 'application/json',
-      'HTTP_ACCEPT'  => 'text/plain',
+    put maximal_section_endpoint, maximal_section.to_json, 'CONTENT_TYPE' => 'application/json',
+      'HTTP_ACCEPT' => 'text/plain',
       'HTTP_AUTHORIZATION' => 'Bearer 12345'
-    }
     expect(response.status).to eq(406)
   end
 
   it 'errors if the Content-Type header is not application/json' do
     stub_any_publishing_api_call
 
-    put maximal_section_endpoint, maximal_section.to_json, {
-      'CONTENT_TYPE' => 'text/plain',
-      'HTTP_ACCEPT'  => 'application/json',
+    put maximal_section_endpoint, maximal_section.to_json, 'CONTENT_TYPE' => 'text/plain',
+      'HTTP_ACCEPT' => 'application/json',
       'HTTP_AUTHORIZATION' => 'Bearer 12345'
-    }
     expect(response.status).to eq(415)
   end
 
@@ -79,8 +75,8 @@ describe 'manual sections resource' do
   end
 
   it 'returns the status code from the Publishing API response, not Rummager' do
-    stub_publishing_api_put_content(maximal_section_content_id, {}, { body: { version: 788 } }) # This returns 200
-    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788}.to_json)
+    stub_publishing_api_put_content(maximal_section_content_id, {}, body: { version: 788 }) # This returns 200
+    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788 }.to_json)
     stub_any_rummager_post # This returns 202, as it does in Production
     stub_publishing_api_get_links(maximal_section_content_id)
     stub_put_default_organisation(maximal_section_content_id)
@@ -105,6 +101,7 @@ describe 'manual sections resource' do
   end
 
 private
+
   def publishing_api_times_out
     stub_request(:any, /#{GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT}\/.*/).to_timeout
   end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -81,7 +81,7 @@ describe 'manual sections resource' do
   it 'returns the status code from the Publishing API response, not Rummager' do
     stub_publishing_api_put_content(maximal_section_content_id, {}, { body: { version: 788 } }) # This returns 200
     stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788}.to_json)
-    stub_any_rummager_post_with_queueing_enabled # This returns 202, as it does in Production
+    stub_any_rummager_post # This returns 202, as it does in Production
     stub_publishing_api_get_links(maximal_section_content_id)
     stub_put_default_organisation(maximal_section_content_id)
 

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -47,7 +47,7 @@ describe 'manuals resource' do
   it 'returns the status code from the Publishing API response, not Rummager' do
     allow_any_instance_of(GdsApi::Response).to receive(:version)
     stub_any_publishing_api_call
-    stub_any_rummager_post_with_queueing_enabled # This returns 202, as it does in Production
+    stub_any_rummager_post # This returns 202, as it does in Production
     stub_publishing_api_get_links(maximal_manual_content_id)
     stub_put_default_organisation(maximal_manual_content_id)
 

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -20,7 +20,7 @@ describe 'manuals resource' do
     expect(response.headers['Content-Type']).to include('application/json')
 
     assert_publishing_api_put_content(maximal_manual_content_id, maximal_manual_for_publishing_api)
-    assert_publishing_api_publish(maximal_manual_content_id, {update_type: 'major'})
+    assert_publishing_api_publish(maximal_manual_content_id, update_type: 'major')
     assert_rummager_posted_item(maximal_manual_for_rummager)
     expect(response.headers['Location']).to include(maximal_manual_url)
     expect(response.body).to include(maximal_manual_url)
@@ -36,7 +36,7 @@ describe 'manuals resource' do
   end
 
   it 'handles Publishing API put_content returning 409' do
-    stub_publishing_api_put_content(maximal_manual_content_id, {}, {status: 409})
+    stub_publishing_api_put_content(maximal_manual_content_id, {}, status: 409)
     stub_any_rummager_post
 
     put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
@@ -70,11 +70,9 @@ describe 'manuals resource' do
     stub_publishing_api_get_links(maximal_manual_content_id)
     stub_put_default_organisation(maximal_manual_content_id)
 
-    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json, {
-      'CONTENT_TYPE' => 'application/json',
+    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json, 'CONTENT_TYPE' => 'application/json',
       'HTTP_ACCEPT' => 'text/plain',
       'HTTP_AUTHORIZATION' => 'Bearer 12345'
-    }
     expect(response.status).to eq(406)
   end
 
@@ -82,11 +80,9 @@ describe 'manuals resource' do
     stub_any_publishing_api_call
     stub_any_rummager_post
 
-    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json, {
-      'CONTENT_TYPE' => 'text/plain',
-      'HTTP_ACCEPT'  => 'application/json',
+    put "/hmrc-manuals/#{maximal_manual_slug}/", maximal_manual.to_json, 'CONTENT_TYPE' => 'text/plain',
+      'HTTP_ACCEPT' => 'application/json',
       'HTTP_AUTHORIZATION' => 'Bearer 12345'
-    }
     expect(response.status).to eq(415)
   end
 end

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -9,8 +9,8 @@ describe "validation" do
 
   let(:malformed_json) { "[" }
   let(:headers) { { 'Content-Type' => 'application/json', 'HTTP_AUTHORIZATION' => 'Bearer 12345678' } }
-  let(:manual_without_title)  { valid_manual.tap {|m| m.delete("title") } }
-  let(:section_without_title) { valid_section.tap {|m| m.delete("title") } }
+  let(:manual_without_title)  { valid_manual.tap { |m| m.delete("title") } }
+  let(:section_without_title) { valid_section.tap { |m| m.delete("title") } }
 
   context "for manuals" do
     it "detects malformed JSON" do
@@ -60,11 +60,11 @@ describe "validation" do
 
       it 'allows images with a relative path' do
         content_id = UUIDTools::UUID.sha1_create(UUIDTools::UUID_URL_NAMESPACE, "/hmrc-internal-manuals/imaginary-slug").to_s
-        stub_publishing_api_put_content(content_id, {}, { body: {version: 22} })
+        stub_publishing_api_put_content(content_id, {}, body: { version: 22 })
         stub_publishing_api_get_links(content_id)
         stub_put_default_organisation(content_id)
 
-        stub_publishing_api_publish(content_id, { update_type: 'minor', previous_version: 22}.to_json)
+        stub_publishing_api_publish(content_id, { update_type: 'minor', previous_version: 22 }.to_json)
         stub_any_rummager_post
 
         manual = valid_manual

--- a/spec/support/ignoring_errors.rb
+++ b/spec/support/ignoring_errors.rb
@@ -1,6 +1,6 @@
 module IgnoringError
-  def ignoring_error(error_class, &block)
-    block.call
+  def ignoring_error(error_class)
+    yield
   rescue error_class
     nil
   end

--- a/spec/support/shared_examples/schema_validation_failures.rb
+++ b/spec/support/shared_examples/schema_validation_failures.rb
@@ -7,7 +7,7 @@ end
 
 RSpec.shared_examples "it validates as a section ID" do
   context 'slashes' do
-    let(:value) { "No/Slashes\\Allowed"}
+    let(:value) { "No/Slashes\\Allowed" }
 
     it_behaves_like "it rejects the value as not matching"
   end


### PR DESCRIPTION
Added lint to the default rake task and fixed the problems.

Also fixes the deprecation warnings:

> DEPRECATION NOTICE: You are making requests that will potentially return nil. Please set `GdsApi.config.always_raise_for_not_found = true` to make sure all responses with 404 or 410 raise an exception. Raising exceptions will be the default behaviour from October 1st, 2016.

and

> stub_any_rummager_post_with_queueing_enabled is deprecated: use stub_any_rummager_post instead

from gds-api-adapters

And corrected the spelling of a private method.