### PR TITLE
Add tasks to redirect manual sections to their parent manuals

### DIFF
--- a/app/models/publishing_api_redirected_section_to_parent_manual.rb
+++ b/app/models/publishing_api_redirected_section_to_parent_manual.rb
@@ -1,0 +1,66 @@
+require 'active_model'
+require 'valid_slug/pattern'
+
+class PublishingAPIRedirectedSectionToParentManual
+  include ActiveModel::Validations
+  include Helpers::PublishingAPIHelpers
+
+  validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+  validates_with InContentStoreValidator,
+    format: SECTION_FORMAT,
+    content_store: Services.content_store,
+    unless: -> {
+      errors[:manual_slug].present? ||
+        errors[:section_slug].present?
+    }
+
+  attr_accessor :manual_slug, :section_slug
+
+  def self.from_rummager_result(rummager_result)
+    raise InvalidJSONError if rummager_result.blank? || rummager_result['link'].blank?
+    slugs = PublishingAPISection.extract_slugs_from_path(rummager_result['link'])
+    new(slugs[:manual], slugs[:section])
+  end
+
+  def initialize(manual_slug, section_slug)
+    @manual_slug = manual_slug
+    @section_slug = section_slug
+  end
+
+  def to_h
+    @_to_h ||= {
+      document_type: 'redirect',
+      schema_name: 'redirect',
+      publishing_app: 'hmrc-manuals-api',
+      base_path: base_path,
+      redirects: [
+        {
+          path: base_path,
+          type: "exact",
+          destination: redirect_to_location
+        }
+      ],
+    }
+  end
+
+  def content_id
+    base_path_uuid
+  end
+
+  def update_type
+    'major'
+  end
+
+  def base_path
+    PublishingAPISection.base_path(manual_slug, section_slug)
+  end
+
+  def redirect_to_location
+    PublishingAPIManual.base_path(manual_slug)
+  end
+
+  def save!
+    raise ValidationError, "manual section to redirect is invalid #{errors.full_messages.to_sentence}" unless valid?
+    PublishingAPINotifier.new(self).notify(update_links: false)
+  end
+end

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -24,10 +24,35 @@ class PublishingAPIRemovedManual
   end
 
   def sections_from_rummager
-    query = RummagerSection.search_query(base_path)
-    Services.rummager.search(query)["results"]
+    sections = []
+    search_response = nil
+
+    loop do
+      new_query = rummager_section_query(start_index(search_response))
+
+      search_response = Services.rummager.search(new_query)
+      sections += search_response["results"]
+      return sections if all_sections_retrieved?(sections, search_response)
+    end
   end
+
   private :sections_from_rummager
+
+  def all_sections_retrieved?(sections, search_response)
+    sections.count >= search_response["total"]
+  end
+
+  def start_index(search_response)
+    if search_response
+      search_response["start"] + search_response["results"].count
+    else
+      0
+    end
+  end
+
+  def rummager_section_query(start_index)
+    RummagerSection.search_query(base_path, start_index)
+  end
 
   def to_h
     @_to_h ||= {

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -18,40 +18,9 @@ class PublishingAPIRemovedManual
   end
 
   def sections
-    sections_from_rummager.map do |section_json|
+    SectionRetriever.new(slug).sections_from_rummager.map do |section_json|
       PublishingAPIRemovedSection.from_rummager_result(section_json)
     end
-  end
-
-  def sections_from_rummager
-    sections = []
-    search_response = nil
-
-    loop do
-      new_query = rummager_section_query(start_index(search_response))
-
-      search_response = Services.rummager.search(new_query)
-      sections += search_response["results"]
-      return sections if all_sections_retrieved?(sections, search_response)
-    end
-  end
-
-  private :sections_from_rummager
-
-  def all_sections_retrieved?(sections, search_response)
-    sections.count >= search_response["total"]
-  end
-
-  def start_index(search_response)
-    if search_response
-      search_response["start"] + search_response["results"].count
-    else
-      0
-    end
-  end
-
-  def rummager_section_query(start_index)
-    RummagerSection.search_query(base_path, start_index)
   end
 
   def to_h

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -39,12 +39,13 @@ class RummagerSection < RummagerBase
     SendToRummagerWorker.perform_async(SECTION_FORMAT, self.id, self.to_h)
   end
 
-  def self.search_query(manual_path)
+  def self.search_query(manual_path, start = 0, count = 1000)
     {
       'filter_format' => SECTION_FORMAT,
-      'filter_organisations' => [GOVUK_HMRC_SLUG],
+      'filter_organisations' => GOVUK_HMRC_SLUG,
       'filter_manual' => manual_path,
-      'count' => '1000',
+      'count' => count,
+      'start' => start,
     }
   end
 end

--- a/lib/section_retriever.rb
+++ b/lib/section_retriever.rb
@@ -1,0 +1,42 @@
+class SectionRetriever
+  attr_reader :manual_slug
+
+  def initialize(manual_slug)
+    @manual_slug = manual_slug
+  end
+
+  def sections_from_rummager
+    sections = []
+    search_response = nil
+
+    loop do
+      new_query = rummager_section_query(start_index(search_response))
+
+      search_response = Services.rummager.search(new_query)
+      sections += search_response["results"]
+      return sections if all_sections_retrieved?(sections, search_response)
+    end
+  end
+
+private
+
+  def all_sections_retrieved?(sections, search_response)
+    sections.count >= search_response["total"]
+  end
+
+  def start_index(search_response)
+    if search_response
+      search_response["start"] + search_response["results"].count
+    else
+      0
+    end
+  end
+
+  def rummager_section_query(start_index)
+    RummagerSection.search_query(base_path, start_index)
+  end
+
+  def base_path
+    PublishingAPIManual.base_path(manual_slug)
+  end
+end

--- a/lib/task_helper.rb
+++ b/lib/task_helper.rb
@@ -1,0 +1,18 @@
+class TaskHelper
+  def self.output_error_message(message)
+    puts "ERROR!"
+    print "  "
+    puts message
+  end
+
+  def self.save_and_output(item)
+    response = item.save!
+    if response.code == 200
+      puts "OK!"
+    else
+      output_error_message(response.raw_response_body)
+    end
+  rescue => e
+    output_error_message(e.message)
+  end
+end

--- a/lib/tasks/remove_manuals.rake
+++ b/lib/tasks/remove_manuals.rake
@@ -1,22 +1,5 @@
 desc "Takes a list of slugs of manuals to remove and makes the appropriate requests to content apis to do so"
 task :remove_hmrc_manuals, [] => :environment do |_task, args|
-  def output_error_message(message)
-    puts "ERROR!"
-    print "  "
-    puts message
-  end
-
-  def remove_and_output(manual)
-    response = manual.save!
-    if response.code == 200
-      puts "OK!"
-    else
-      output_error_message(response.raw_response_body)
-    end
-  rescue => e
-    output_error_message(e.message)
-  end
-
   slugs = args.extras
   if slugs.empty?
     puts "Usage: rake remove_hmrc_manuals[slug-to-remove-1,slug-to-remove-2,...,slug-to-remove-n]"
@@ -26,9 +9,9 @@ task :remove_hmrc_manuals, [] => :environment do |_task, args|
       manual = PublishingAPIRemovedManual.new(manual_slug)
       manual.sections.each do |section|
         print "  Removing section '#{manual_slug}/#{section.section_slug}'"
-        remove_and_output(section)
+        TaskHelper.save_and_output(section)
       end
-      remove_and_output(manual)
+      TaskHelper.save_and_output(manual)
     end
   end
 end

--- a/lib/tasks/remove_sections.rake
+++ b/lib/tasks/remove_sections.rake
@@ -1,22 +1,5 @@
 desc "Takes a list of slugs of section to remove and makes the appropriate requests to content apis to do so"
 task :remove_hmrc_sections, [] => :environment do |_task, args|
-  def output_error_message(message)
-    puts "ERROR!"
-    print "  "
-    puts message
-  end
-
-  def remove_and_output(section)
-    response = section.save!
-    if response.code == 200
-      puts "OK!"
-    else
-      output_error_message(response.raw_response_body)
-    end
-  rescue => e
-    output_error_message(e.message)
-  end
-
   slugs = args.extras
   if slugs.empty?
     puts "Usage: rake remove_hmrc_sections[manual-slug,slug-to-remove-1,slug-to-remove-2,...,slug-to-remove-n]"
@@ -26,7 +9,7 @@ task :remove_hmrc_sections, [] => :environment do |_task, args|
     slugs.each do |section_slug|
       print "Removing section '#{section_slug}': "
       section = PublishingAPIRemovedSection.new(manual_slug, section_slug)
-      remove_and_output(section)
+      TaskHelper.save_and_output(section)
     end
   end
 end

--- a/spec/lib/section_retriever_spec.rb
+++ b/spec/lib/section_retriever_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe SectionRetriever do
+  describe '#sections_from_rummager' do
+    subject(:section_retriever) { described_class.new('some-manual-slug') }
+
+    it 'asks rummager for all the hmrc manual sections under its slug' do
+      rummager_query = stub_request(:get, %r{/search.json})
+        .to_return(body: no_manual_sections_rummager_json_result)
+
+      subject.sections_from_rummager.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+
+      assert_requested rummager_query
+    end
+
+    it 'exposes each result from rummager as the specified Section type' do
+      stub_request(:get, %r{/search.json})
+        .to_return(body: two_manual_sections_rummager_json_result('some-manual-slug'))
+
+      sections = subject.sections_from_rummager.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+      expect(sections.size).to eq(2)
+
+      expect(sections.first).to be_a PublishingAPIRemovedSection
+      expect(sections.first.manual_slug).to eq('some-manual-slug')
+      expect(sections.first.section_slug).to eq('section-1')
+
+      expect(sections.last).to be_a PublishingAPIRemovedSection
+      expect(sections.last.manual_slug).to eq('some-manual-slug')
+      expect(sections.last.section_slug).to eq('section-2')
+    end
+
+    it 'exposes the error from rummager if the rummager call fails' do
+      stub_request(:get, %r{/search.json})
+        .to_return(status: 503, body: '{"error":"arg!"}')
+
+      expect {
+        subject.sections_from_rummager.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+      }.to raise_error(GdsApi::BaseError)
+    end
+
+    describe 'paging through sections' do
+      subject(:section_retriever) { described_class.new('some-manual-slug') }
+
+      it 'gets all sections when there is more than one page of results' do
+        stub_request(:get, %r{/search.json?.+start=0})
+          .to_return(body: one_of_two_manual_sections_rummager_json_result('some-manual-slug'))
+
+        stub_request(:get, %r{/search.json?.+start=1})
+          .to_return(body: two_of_two_manual_sections_rummager_json_result('some-manual-slug'))
+
+        sections = subject.sections_from_rummager.map { |json| PublishingAPIRedirectedSectionToParentManual.from_rummager_result(json) }
+        expect(sections.size).to eq(2)
+
+        expect(sections.first).to be_a PublishingAPIRedirectedSectionToParentManual
+        expect(sections.first.manual_slug).to eq('some-manual-slug')
+        expect(sections.first.section_slug).to eq('section-1')
+
+        expect(sections.last).to be_a PublishingAPIRedirectedSectionToParentManual
+        expect(sections.last.manual_slug).to eq('some-manual-slug')
+        expect(sections.last.section_slug).to eq('section-2')
+      end
+    end
+  end
+end

--- a/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+require 'gds_api/test_helpers/rummager'
+require 'gds_api/test_helpers/content_store'
+
+describe PublishingAPIRedirectedSectionToParentManual do
+  describe 'validations' do
+    let(:manual_slug) { "manual" }
+    let(:section_slug) { "section" }
+    subject(:redirected_manual) { described_class.new(manual_slug, section_slug) }
+
+    context 'validating slug format' do
+      it { should_not allow_value(nil, "1Som\nSłu9G!").for(:manual_slug) }
+      it { should_not allow_value(nil, "1Som\nSłu9G!").for(:section_slug) }
+    end
+
+    context 'checking that the manual section exists already' do
+      include GdsApi::TestHelpers::ContentStore
+      let(:section_path) { subject.base_path }
+
+      it 'is invalid if the slugs do not represent a piece of content' do
+        content_store_does_not_have_item(section_path)
+        expect(subject).not_to be_valid
+      end
+
+      it 'is invalid if the slugs already represent a "gone" piece of content' do
+        content_item = content_item_for_base_path(section_path).merge("format" => "gone")
+        content_store_has_item(section_path, content_item)
+        expect(subject).not_to be_valid
+      end
+
+      it 'is valid when the slugs represent an "hmrc-manual-section" piece of content' do
+        content_item = hmrc_manual_section_content_item_for_base_path(section_path)
+        content_store_has_item(section_path, content_item)
+        expect(subject).to be_valid
+      end
+
+      it 'is invalid when the slugs represent any other format piece of content' do
+        content_store_has_item(section_path)
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+
+  describe '#to_h' do
+    let(:redirected_manual_section) { described_class.new('some-manual', 'some-section') }
+    subject(:redirected_manual_section_as_hash) { redirected_manual_section.to_h }
+
+    context 'valid schema' do
+      it { should be_valid_against_schema('redirect') }
+    end
+
+    it 'is a "redirect" document type' do
+      expect(subject[:document_type]).to eq('redirect')
+    end
+
+    it 'is published by the "hmrc-manuals-api" app' do
+      expect(subject[:publishing_app]).to eq('hmrc-manuals-api')
+    end
+  end
+
+  describe '#save!' do
+    include GdsApi::TestHelpers::PublishingApiV2
+    include GdsApi::TestHelpers::Rummager
+    include GdsApi::TestHelpers::ContentStore
+    before do
+      content_item = hmrc_manual_section_content_item_for_base_path(subject.base_path)
+      content_store_has_item(subject.base_path, content_item)
+    end
+
+    describe 'for an invalid manual section' do
+      subject(:removed_manual_section) { described_class.new('this_is_not_acc3ptABLE!', 'is it?') }
+
+      it 'raises a validation error' do
+        expect { subject.save! }.to raise_error(ValidationError)
+      end
+
+      it 'does not communicate with the publishing api' do
+        publishing_api_stub = stub_any_publishing_api_put_content
+
+        ignoring_error(ValidationError) { subject.save! }
+
+        assert_not_requested publishing_api_stub
+      end
+    end
+
+    describe 'for a valid manual section' do
+      subject(:redirected_manual_section) { described_class.new('some-manual', 'some-section') }
+
+      it 'issues put_content and publish requests to the publishing api to mark the manual section as gone' do
+        stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
+        stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
+
+        subject.save!
+
+        assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_manual_for_publishing_api)
+        assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
+      end
+    end
+  end
+
+  def hmrc_manual_section_content_item_for_base_path(base_path)
+    content_item_for_base_path(base_path).merge("format" => SECTION_FORMAT)
+  end
+end

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -155,6 +155,22 @@ module PublishingApiDataHelpers
       ],
     }
   end
+
+  def redirected_manual_section_to_manual_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section')
+    {
+      'document_type' => 'redirect',
+      'schema_name' => 'redirect',
+      'publishing_app' => 'hmrc-manuals-api',
+      'base_path' => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
+      'redirects' => [
+        {
+          'path' => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
+          'type' => "exact",
+          'destination' => "/hmrc-internal-manuals/#{manual_slug}"
+        }
+      ],
+    }
+  end
 end
 
 RSpec.configuration.include PublishingApiDataHelpers

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -26,15 +26,6 @@ module RummagerHelpers
     }
   end
 
-  def search_for_sections_rummager_query(manual_slug)
-    {
-      'filter_format' => 'hmrc_manual_section',
-      'filter_organisations' => ['hm-revenue-customs'],
-      'filter_manual' => "/hmrc-internal-manuals/#{manual_slug}",
-      'count' => '1000',
-    }
-  end
-
   def no_manual_sections_rummager_json_result
     <<-JSON.strip_heredoc
       {
@@ -114,6 +105,70 @@ module RummagerHelpers
         ],
         "total":2,
         "start":0,
+        "facets":{},
+        "suggested_queries":[]
+      }
+    JSON
+  end
+
+  def one_of_two_manual_sections_rummager_json_result(manual_slug)
+    <<-JSON.strip_heredoc
+      {
+        "results":[
+          {
+            "format":"hmrc_manual_section",
+            "link":"/hmrc-internal-manuals/#{manual_slug}/section-1",
+            "organisations":[
+              {
+                "slug":"hm-revenue-customs",
+                "title":"HM Revenue & Customs",
+                "acronym":"HMRC",
+                "organisation_state":"live",
+                "link":"/government/organisations/hm-revenue-customs"
+              }
+            ],
+            "public_timestamp":"2015-02-03T16:30:33+00:00",
+            "title":"section 1",
+            "index":"mainstream",
+            "es_score":null,
+            "_id":"/hmrc-internal-manuals/#{manual_slug}/section-1",
+            "document_type":"hmrc_manual_section"
+          }
+        ],
+        "total":2,
+        "start":0,
+        "facets":{},
+        "suggested_queries":[]
+      }
+    JSON
+  end
+
+  def two_of_two_manual_sections_rummager_json_result(manual_slug)
+    <<-JSON.strip_heredoc
+      {
+        "results":[
+          {
+            "format":"hmrc_manual_section",
+            "link":"/hmrc-internal-manuals/#{manual_slug}/section-2",
+            "organisations":[
+              {
+                "slug":"hm-revenue-customs",
+                "title":"HM Revenue & Customs",
+                "acronym":"HMRC",
+                "organisation_state":"live",
+                "link":"/government/organisations/hm-revenue-customs"
+              }
+            ],
+            "public_timestamp":"2015-02-10T15:56:49+00:00",
+            "title":"section 2",
+            "index":"mainstream",
+            "es_score":null,
+            "_id":"/hmrc-internal-manuals/#{manual_slug}/section-2",
+            "document_type":"hmrc_manual_section"
+          }
+        ],
+        "total":2,
+        "start":1,
         "facets":{},
         "suggested_queries":[]
       }


### PR DESCRIPTION
Added the ability to page over Rummager results, as we know that there are manuals
 with over 1000 sections (and at least one with > 5000)

Added two rake tasks: `redirect_hmrc_section_to_parent_manual` and
`redirect_all_sections_to_parent_manual`.  At present we don't have any need
to redirect sections to other manuals or manuals to other manuals.

The `redirect_all_sections_to_parent_manual' task outputs the source and
destination slugs which could be handy if something went awry.

Added a new model `PublishingAPIRedirectedSectionToParentManual` in the same
vein as `PublishingAPIRedirectedSection`.  There seems to be enough difference
in the validations (for example) to keep it separate.

Added a `SectionRetriever` class to encapsulate the construction and execution
of Rummager queries, and allow construction of result items as required so we
can construct both the `Redirected` and `Removed` section types from it.
I tried shoehorning it into `PublishingAPIManual`, but it didn't seem to fit
very nicely.  We don't need it for anything that PublishingAPIManual does at
the moment, so it seemed wrong to add complexity there.

Also removed some duplication from the remove/redirect rake tasks

https://trello.com/c/Wu6gbYDj/464-unpublish-pages-from-hmrc-manuals