### PR TITLE
Allow redirecting sections to other manuals

### DIFF
--- a/app/models/publishing_api_redirected_section.rb
+++ b/app/models/publishing_api_redirected_section.rb
@@ -5,20 +5,20 @@ class PublishingAPIRedirectedSection
   include ActiveModel::Validations
   include Helpers::PublishingAPIHelpers
 
-  validates :manual_slug, :section_slug, :destination_manual_slug, :destination_section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+  validates :manual_slug, :section_slug, :destination_manual_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
+  validates :destination_section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }, allow_nil: true
   validates_with InContentStoreValidator,
     format: SECTION_FORMAT,
     content_store: Services.content_store,
     unless: -> {
       errors[:manual_slug].present? ||
         errors[:section_slug].present? ||
-        errors[:destination_manual_slug].present? ||
-        errors[:destination_section_slug].present?
+        errors[:destination_manual_slug].present?
     }
 
   attr_accessor :manual_slug, :section_slug, :destination_manual_slug, :destination_section_slug
 
-  def initialize(manual_slug, section_slug, destination_manual_slug, destination_section_slug)
+  def initialize(manual_slug, section_slug, destination_manual_slug, destination_section_slug = nil)
     @manual_slug = manual_slug
     @section_slug = section_slug
     @destination_manual_slug = destination_manual_slug
@@ -54,7 +54,11 @@ class PublishingAPIRedirectedSection
   end
 
   def redirect_to_location
-    PublishingAPISection.base_path(destination_manual_slug, destination_section_slug)
+    if destination_section_slug.present?
+      PublishingAPISection.base_path(destination_manual_slug, destination_section_slug)
+    else
+      PublishingAPIManual.base_path(destination_manual_slug)
+    end
   end
 
   def save!

--- a/app/models/publishing_api_redirected_section_to_parent_manual.rb
+++ b/app/models/publishing_api_redirected_section_to_parent_manual.rb
@@ -1,66 +1,11 @@
-require 'active_model'
-require 'valid_slug/pattern'
-
-class PublishingAPIRedirectedSectionToParentManual
-  include ActiveModel::Validations
-  include Helpers::PublishingAPIHelpers
-
-  validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
-  validates_with InContentStoreValidator,
-    format: SECTION_FORMAT,
-    content_store: Services.content_store,
-    unless: -> {
-      errors[:manual_slug].present? ||
-        errors[:section_slug].present?
-    }
-
-  attr_accessor :manual_slug, :section_slug
+class PublishingAPIRedirectedSectionToParentManual < PublishingAPIRedirectedSection
+  def initialize(manual_slug, section_slug)
+    super(manual_slug, section_slug, manual_slug)
+  end
 
   def self.from_rummager_result(rummager_result)
     raise InvalidJSONError if rummager_result.blank? || rummager_result['link'].blank?
     slugs = PublishingAPISection.extract_slugs_from_path(rummager_result['link'])
     new(slugs[:manual], slugs[:section])
-  end
-
-  def initialize(manual_slug, section_slug)
-    @manual_slug = manual_slug
-    @section_slug = section_slug
-  end
-
-  def to_h
-    @_to_h ||= {
-      document_type: 'redirect',
-      schema_name: 'redirect',
-      publishing_app: 'hmrc-manuals-api',
-      base_path: base_path,
-      redirects: [
-        {
-          path: base_path,
-          type: "exact",
-          destination: redirect_to_location
-        }
-      ],
-    }
-  end
-
-  def content_id
-    base_path_uuid
-  end
-
-  def update_type
-    'major'
-  end
-
-  def base_path
-    PublishingAPISection.base_path(manual_slug, section_slug)
-  end
-
-  def redirect_to_location
-    PublishingAPIManual.base_path(manual_slug)
-  end
-
-  def save!
-    raise ValidationError, "manual section to redirect is invalid #{errors.full_messages.to_sentence}" unless valid?
-    PublishingAPINotifier.new(self).notify(update_links: false)
   end
 end

--- a/lib/tasks/redirect_sections.rake
+++ b/lib/tasks/redirect_sections.rake
@@ -1,8 +1,12 @@
-desc "Redirect a section, takes original manual slug, section slug, destination manual slug and destination section slug"
+desc "Redirect a section, takes original manual slug, section slug, destination manual slug and (optional) destination section slug"
 task :redirect_hmrc_section, [] => :environment do |_task, args|
   slugs = args.extras
-  if slugs.empty? || slugs.length < 4
-    puts "Usage: rake redirect_hmrc_section[manual-slug,section-slug-to-redirect,destination-manual-slug,destination-section-slug]"
+  if slugs.empty? || slugs.length < 3
+    puts %{Usage:
+  rake redirect_hmrc_section[manual-slug,section-slug-to-redirect,destination-manual-slug]
+or
+  rake redirect_hmrc_section[manual-slug,section-slug-to-redirect,destingation-manual-slug,destination-section-slug]
+}
   else
     manual_slug = slugs[0]
     section_slug = slugs[1]

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -4,6 +4,8 @@ require 'gds_api/test_helpers/rummager'
 require 'gds_api/test_helpers/content_store'
 
 describe PublishingAPIRedirectedSection do
+  include GdsApi::TestHelpers::ContentStore
+
   describe 'validations' do
     let(:manual_slug) { "manual" }
     let(:section_slug) { "section" }
@@ -12,14 +14,15 @@ describe PublishingAPIRedirectedSection do
     subject(:redirected_manual) { described_class.new(manual_slug, section_slug, destination_manual_slug, destination_section_slug) }
 
     context 'validating slug format' do
+      before { stub_request(:any, %r{\A#{content_store_endpoint}}).to_return(status: 404, body: '{}') }
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:manual_slug) }
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:section_slug) }
       it { should_not allow_value(nil, "1Som\nSłu9G!").for(:destination_manual_slug) }
-      it { should_not allow_value(nil, "1Som\nSłu9G!").for(:destination_section_slug) }
+      it { should allow_value(nil).for(:destination_section_slug) }
+      it { should_not allow_value("1Som\nSłu9G!").for(:destination_section_slug) }
     end
 
     context 'checking that the manual section exists already' do
-      include GdsApi::TestHelpers::ContentStore
       let(:section_path) { subject.base_path }
 
       it 'is invalid if the slugs do not represent a piece of content' do
@@ -46,6 +49,22 @@ describe PublishingAPIRedirectedSection do
     end
   end
 
+  describe '#redirect_to_location' do
+    context 'for a redirect to another manual section' do
+      it 'is the path to the manual section' do
+        redirect_to_location = described_class.new('old-manual', 'old-section', 'redirect-manual', 'redirect-section').redirect_to_location
+        expect(redirect_to_location).to eql('/hmrc-internal-manuals/redirect-manual/redirect-section')
+      end
+    end
+
+    context 'for a redirect to another manual' do
+      it 'is the path to the manual section' do
+        redirect_to_location = described_class.new('old-manual', 'old-section', 'redirect-manual').redirect_to_location
+        expect(redirect_to_location).to eql('/hmrc-internal-manuals/redirect-manual')
+      end
+    end
+  end
+
   describe '#to_h' do
     let(:redirected_manual_section) { described_class.new('some-manual', 'some-section', 'manual-redirect', 'section-redirect') }
     subject(:redirected_manual_section_as_hash) { redirected_manual_section.to_h }
@@ -66,7 +85,7 @@ describe PublishingAPIRedirectedSection do
   describe '#save!' do
     include GdsApi::TestHelpers::PublishingApiV2
     include GdsApi::TestHelpers::Rummager
-    include GdsApi::TestHelpers::ContentStore
+
     before do
       content_item = hmrc_manual_section_content_item_for_base_path(subject.base_path)
       content_store_has_item(subject.base_path, content_item)
@@ -89,16 +108,32 @@ describe PublishingAPIRedirectedSection do
     end
 
     describe 'for a valid manual section' do
-      subject(:redirected_manual_section) { described_class.new('some-manual', 'some-section', 'some-other-manual', 'some-other-section') }
+      context 'being redirected to another manual section' do
+        subject(:redirected_manual_section) { described_class.new('some-manual', 'some-section', 'some-other-manual', 'some-other-section') }
 
-      it 'issues put_content and publish requests to the publishing api to mark the manual section as gone' do
-        stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
-        stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
+        it 'issues put_content and publish requests to the publishing api to mark the manual section as redirected' do
+          stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
+          stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
 
-        subject.save!
+          subject.save!
 
-        assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_for_publishing_api)
-        assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
+          assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_other_manual_section_for_publishing_api)
+          assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
+        end
+      end
+
+      context 'being redirected to another manual' do
+        subject(:redirected_manual_section) { described_class.new('some-manual', 'some-section', 'some-other-manual') }
+
+        it 'issues put_content and publish requests to the publishing api to mark the manual section as redirected' do
+          stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
+          stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
+
+          subject.save!
+
+          assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_other_manual_for_publishing_api)
+          assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
+        end
       end
     end
   end

--- a/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
@@ -93,7 +93,7 @@ describe PublishingAPIRedirectedSectionToParentManual do
 
         subject.save!
 
-        assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_manual_for_publishing_api)
+        assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_parent_manual_for_publishing_api)
         assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
       end
     end

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -140,7 +140,7 @@ module PublishingApiDataHelpers
     }
   end
 
-  def redirected_manual_section_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section', dest_manual_slug: 'some-other-manual', dest_section_slug: 'some-other-section')
+  def redirected_manual_section_to_other_manual_section_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section', dest_manual_slug: 'some-other-manual', dest_section_slug: 'some-other-section')
     {
       'document_type' => 'redirect',
       'schema_name' => 'redirect',
@@ -156,7 +156,23 @@ module PublishingApiDataHelpers
     }
   end
 
-  def redirected_manual_section_to_manual_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section')
+  def redirected_manual_section_to_other_manual_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section', dest_manual_slug: 'some-other-manual')
+    {
+      'document_type' => 'redirect',
+      'schema_name' => 'redirect',
+      'publishing_app' => 'hmrc-manuals-api',
+      'base_path' => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
+      'redirects' => [
+        {
+          'path' => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
+          'type' => "exact",
+          'destination' => "/hmrc-internal-manuals/#{dest_manual_slug}"
+        }
+      ],
+    }
+  end
+
+  def redirected_manual_section_to_parent_manual_for_publishing_api(manual_slug: 'some-manual', section_slug: 'some-section')
     {
       'document_type' => 'redirect',
       'schema_name' => 'redirect',


### PR DESCRIPTION
To support some of the zendesk tickets in: https://trello.com/c/2pxsDfWf/103-unpublish-hmrc-manual-sections

We already support redirecting a section to another section, or to it's parent manual.  This change allows us to redirect a section to another manual root.