### PR TITLE
Add content_store_document_type to Rummager Manual & Rummager Section

### DIFF
--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -14,6 +14,7 @@ class RummagerManual < RummagerBase
       'content_id'         => @content_id,
       'title'              => @publishing_api_manual['title'],
       'description'        => @publishing_api_manual['description'],
+      'content_store_document_type' => MANUAL_FORMAT,
       'link'               => id,
       'indexable_content'  => nil,
       'public_timestamp'   => @publishing_api_manual['public_updated_at'],

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -27,6 +27,7 @@ class RummagerSection < RummagerBase
       'title'                   => title,
       'description'             => @publishing_api_section['description'],
       'link'                    => id,
+      'content_store_document_type' => SECTION_FORMAT,
       'indexable_content'       => body_without_html,
       'public_timestamp'        => @publishing_api_section['public_updated_at'],
       'hmrc_manual_section_id'  => section_id,

--- a/spec/support/rummager_helpers.rb
+++ b/spec/support/rummager_helpers.rb
@@ -4,6 +4,7 @@ module RummagerHelpers
       'content_id'         => '913fd52f-072c-409e-88b2-ea0b7a8b6d9c',
       'title'              => 'Employment Income Manual',
       'description'        => 'A manual about incoming employment',
+      'content_store_document_type' => 'hmrc_manual',
       'link'               => '/hmrc-internal-manuals/employment-income-manual',
       'indexable_content'  => nil,
       'public_timestamp'   => '2014-01-23T00:00:00+01:00',
@@ -17,6 +18,7 @@ module RummagerHelpers
       'content_id'             => '25e687b8-74da-4892-938d-7de82fa5df27',
       'title'                  => '12345 - A section on a part of employment income',
       'description'            => 'Some description',
+      'content_store_document_type' => 'hmrc_manual_section',
       'link'                   => '/hmrc-internal-manuals/employment-income-manual/12345',
       'indexable_content'      => 'I need somebody to love', # Markdown/HTML has been stripped
       'public_timestamp'       => '2014-01-23T00:00:00+01:00',


### PR DESCRIPTION
Finding Things has been working into adding a new field in rummager
called `content_store_document_type`. This commit does exactly that in
both RummagerManual & RummagerSection.

Trello:
https://trello.com/c/iMotNdUv/461-add-more-document-type-to-search