### PR TITLE
Remove inward-processing-relief from list of slugs

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -94,7 +94,6 @@ KNOWN_MANUAL_SLUGS = %w{
   international-exchange-of-information
   international-manual
   introduction-to-administrative-co-operation-in-excise
-  inward-processing-relief
   labour-provider-operational-guidance
   landfill-tax-liability
   lloyds-manual


### PR DESCRIPTION
HMRC have requested we remove inward-processing-relief because this manual has been replaced by customs-special-procedures