### PR TITLE
Add documentation from the Ops Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See the [extended documentation](docs/extended_documentation.md) for details:
 - [Content Ids](docs/extended_documentation.md#content-ids)
 - [Markup](docs/extended_documentation.md#markup)
 - [Manual Tags](docs/extended_documentation.md#manual-tags)
+- [Removing published manuals](docs/extended_documentation.md#removing-published-manuals)
 - [Testing publishing in the GOVUK dev vm](docs/extended_documentation.md#testing-publishing-in-the-govuk-development-vm)
 
 ### Dependencies

--- a/docs/extended_documentation.md
+++ b/docs/extended_documentation.md
@@ -184,6 +184,17 @@ users to find.
 
 Use the [content-tagger](https://github.com/alphagov/content-tagger) app to add topic tags to manuals.
 
+## Removing published manuals
+
+The API endpoints of the app do not cover removal of manuals. There is a rake task for this purpose. Removal means deleting the manual from rummager and replacing the published manual with a 410 Gone document. As manuals can have sections underneath them removal does the same for each section that is a child of the manual.
+
+The rake task is invoked as follows:
+
+```
+$ cd /var/apps/hmrc-manuals-api
+$ sudo -u deploy govuk_setenv hmrc-manuals-api bundle exec rake remove_hmrc_manuals[slug-to-remove-1,slug-to-remove-2,...,slug-to-remove-n]
+```
+
 ## Testing publishing in the GOV.UK development VM
 
 You can use the JSON examples of requests for testing publishing in development,


### PR DESCRIPTION
We are moving documentation out of the Ops Manual - this commit adds the
documentation about hmrc-manuals-api from the Ops Manual to this repo.

[Trello card](https://trello.com/c/5x8NHLhf/40-merge-opsmanual-into-developer-docs)