### PR TITLE
Add civil-evasion-penalties-for-customs-excise-and-vat to known slugs

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -21,6 +21,7 @@ KNOWN_MANUAL_SLUGS = %w{
   child-benefit-manual
   child-benefit-technical-manual
   cider-guidance
+  civil-evasion-penalties-for-customs-excise-and-vat
   claimant-compliance-manual
   climate-change-levy-guidance
   collection-of-student-loans-manual


### PR DESCRIPTION
https://trello.com/c/yGCpbWlF/937-hmrc-manual-add-a-slug

Adds the slug `civil-evasion-penalties-for-customs-excise-and-vat` to the known manuals list.