### PR TITLE
Add `banking-manual` to known manual slugs

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -10,6 +10,7 @@ KNOWN_MANUAL_SLUGS = %w{
   apprenticeship-levy
   ata-cpd-carnets
   bank-levy-manual
+  banking-manual
   beer-manual
   biofuels-and-fuel-substitutes-assurance
   bona-vacantia-manual


### PR DESCRIPTION
Adds the slug `banking-manual` to the list of known manual slugs.

[Trello](https://trello.com/c/YZqVLT7u/53-05-hmrc-manual-add-a-slug)
