### PR TITLE
Change Airbrake configuration to use an environment variable for api_key

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,7 +1,10 @@
-# This file is overwritten on deploy
-#
-Airbrake.configure do |config|
-  # Adding "production" to the development environments causes Airbrake not
-  # to attempt to send notifications.
-  config.development_environments << "production"
+if ENV['ERRBIT_API_KEY'].present?
+  errbit_uri = Plek.find_uri('errbit')
+
+  Airbrake.configure do |config|
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/pEx2HlBB

Related to:
1. https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/pull/1336
2. https://github.digital.cabinet-office.gov.uk/gds/deployment/pull/1372
3. https://github.com/alphagov/govuk-puppet/pull/6135

## Motivation

HMRC Manuals API uses config in [alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) to set the values for Airbrake including the `errbit_api_key`. [alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) is an application that has been deprecated, and all config in there should be moved to environment variables.