### PR TITLE
Update Redis config to use environment variables

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,8 @@
-redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_keys
+redis_config = {
+  host: ENV["REDIS_HOST"] || "127.0.0.1",
+  port: ENV["REDIS_PORT"] || 6379,
+  namespace: "hmrc-manuals-api",
+}
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,0 @@
-host: 127.0.0.1
-port: 6379
-namespace: hmrc-manuals-api


### PR DESCRIPTION
Trello: https://trello.com/c/jpPE9GXd

Related to:
1. https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/pull/1337
2. https://github.com/alphagov/govuk-puppet/pull/6136

## Motivation

Unlike most other GOV.UK applications, HMRC Manuals API uses config in [alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) to set the values for Redis. 

[alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) is an application that has been deprecated, and all config in there should be moved to environment variables.