### PR TITLE
Include instructions to create a new manual in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ This app provides URLs for pushing HMRC manuals to the GOV.UK Publishing API.
 
 ## Nomenclature
 
-- **Manual**: HMRC manual with title and description, contains many Sections. See [Adding or updating a manual](docs/extended_documentation.md#adding-or-updating-a-manual) for more details
+- **Manual**: HMRC manual with title and description, contains many Sections. See [Adding or updating a manual](docs/extended_documentation.md#adding-or-updating-a-manual) for more details. Before adding a manual through the api, a [new slug should be added](#adding-a-new-slug) to the list of known slugs.
 
-- **Section**: Sections can contain sub-sections and/or a content body. See [Adding or updating a section](docs/extended_documentation.md#adding-or-updating-a-manual-section) for more details
+- **Section**: Sections can contain sub-sections and/or a content body. See [Adding or updating a section](docs/extended_documentation.md#adding-or-updating-a-manual-section) for more details.
+
+<a name="adding-a-new-slug"></a>
+## Adding a new slug
+
+Before adding a new manual through the api, the slug for the manual must be added to [/config/initializers/known_manual_slugs.rb](config/initializers/known_manual_slugs.rb) and the application re-deployed.
+
+The workflow for this is likely to be initiated by a zendesk ticket raised by HMRC with the new slug. A developer can
+then add the slug and re-deploy the application and inform HMRC that the slug is ready to be published against.
 
 ## Technical documentation
 


### PR DESCRIPTION
Update the README to include instructions on how to create a new manual.