### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-r
 gem 'json-schema', '2.5.1'
 gem 'gds-sso', '~> 13.2.0'
 gem 'plek', '1.11.0'
-gem 'gds-api-adapters', '36.0.1'
+gem 'gds-api-adapters', '47.2'
 gem 'govspeak', '~> 3.3.0'
 gem 'sidekiq', '3.4.2'
 gem 'uuidtools', '2.1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     ffi (1.9.18)
     foreman (0.78.0)
       thor (~> 0.19.1)
-    gds-api-adapters (36.0.1)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -310,7 +310,7 @@ DEPENDENCIES
   airbrake!
   ci_reporter_rspec (= 1.0.0)
   foreman (= 0.78.0)
-  gds-api-adapters (= 36.0.1)
+  gds-api-adapters (= 47.2)
   gds-sso (~> 13.2.0)
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (= 1.3.0)
@@ -333,4 +333,4 @@ DEPENDENCIES
   webmock (= 1.18.0)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -23,7 +23,7 @@ class PublishingAPIManual
 
   def to_h
     @_to_h ||= begin
-      enriched_data = @manual_attributes.except('content_id', 'update_type').deep_dup.merge(base_path: base_path,
+      enriched_data = @manual_attributes.except('content_id').deep_dup.merge(base_path: base_path,
         document_type: MANUAL_FORMAT,
         schema_name: MANUAL_FORMAT,
         publishing_app: 'hmrc-manuals-api',

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -23,7 +23,7 @@ private
   def publish(version)
     Services.publishing_api.publish(
       @document.content_id,
-      @document.update_type,
+      nil, #this is update_type, which is being deprecated. We still need to pass it for now.
       previous_version: version
     )
   end

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,7 +1,0 @@
-GdsApi.configure do |config|
-  # Never return nil when a server responds with 404 or 410.
-  config.always_raise_for_not_found = true
-
-  # Return a hash, not an OpenStruct from a request.
-  config.hash_response_for_requests = true
-end

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -113,12 +113,12 @@ describe PublishingAPIRedirectedSection do
 
         it 'issues put_content and publish requests to the publishing api to mark the manual section as redirected' do
           stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
-          stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
+          stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: nil, previous_version: 33 }.to_json)
 
           subject.save!
 
           assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_other_manual_section_for_publishing_api)
-          assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
+          assert_publishing_api_publish(redirected_manual_section.content_id, update_type: nil, previous_version: 33)
         end
       end
 
@@ -127,12 +127,12 @@ describe PublishingAPIRedirectedSection do
 
         it 'issues put_content and publish requests to the publishing api to mark the manual section as redirected' do
           stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
-          stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
+          stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: nil, previous_version: 33 }.to_json)
 
           subject.save!
 
           assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_other_manual_for_publishing_api)
-          assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
+          assert_publishing_api_publish(redirected_manual_section.content_id, update_type: nil, previous_version: 33)
         end
       end
     end

--- a/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
@@ -89,12 +89,12 @@ describe PublishingAPIRedirectedSectionToParentManual do
 
       it 'issues put_content and publish requests to the publishing api to mark the manual section as gone' do
         stub_publishing_api_put_content(redirected_manual_section.content_id, {}, body: { version: 33 })
-        stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
+        stub_publishing_api_publish(redirected_manual_section.content_id, { update_type: nil, previous_version: 33 }.to_json)
 
         subject.save!
 
         assert_publishing_api_put_content(redirected_manual_section.content_id, redirected_manual_section_to_parent_manual_for_publishing_api)
-        assert_publishing_api_publish(redirected_manual_section.content_id, update_type: redirected_manual_section.update_type, previous_version: 33)
+        assert_publishing_api_publish(redirected_manual_section.content_id, update_type: nil, previous_version: 33)
       end
     end
   end

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -165,13 +165,13 @@ describe PublishingAPIRemovedManual do
 
       it 'issues a put_content and publish requests to the publishing api to mark the manual as gone' do
         stub_publishing_api_put_content(removed_manual.content_id, {}, status: 201, body: { version: 4 }.to_json)
-        stub_publishing_api_publish(removed_manual.content_id, { update_type: 'major', previous_version: 4 }.to_json)
+        stub_publishing_api_publish(removed_manual.content_id, { update_type: nil, previous_version: 4 }.to_json)
         stub_any_rummager_delete
 
         subject.save!
 
         assert_publishing_api_put_content(removed_manual.content_id, gone_manual)
-        assert_publishing_api_publish(removed_manual.content_id, update_type: 'major', previous_version: 4)
+        assert_publishing_api_publish(removed_manual.content_id, update_type: nil, previous_version: 4)
 
         #TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`
         #      once https://github.com/alphagov/gds-api-adapters/pull/362 has been merged

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -124,7 +124,7 @@ describe PublishingAPIRemovedSection do
 
       it 'issues put_content and publish requests to the publishing api to mark the manual section as gone' do
         stub_publishing_api_put_content(removed_manual_section.content_id, {}, body: { version: 33 })
-        stub_publishing_api_publish(removed_manual_section.content_id, { update_type: 'major', previous_version: 33 }.to_json)
+        stub_publishing_api_publish(removed_manual_section.content_id, { update_type: nil, previous_version: 33 }.to_json)
         stub_any_rummager_delete
 
         subject.save!
@@ -132,7 +132,7 @@ describe PublishingAPIRemovedSection do
         assert_publishing_api_put_content(removed_manual_section.content_id, gone_manual_section_for_publishing_api)
         assert_publishing_api_publish(
           removed_manual_section.content_id,
-          update_type: removed_manual_section.update_type, previous_version: 33
+          update_type: nil, previous_version: 33
         )
 
         # TODO: Update this with `assert_rummager_deleted_item(publishing_api_base_path[1..-1])`

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -18,7 +18,7 @@ describe PublishingAPINotifier do
     it "makes calls to update the document, publish it, and update its links via the publishing API" do
       expect(Services.publishing_api).to receive(:put_content).with(content_id, document_hash)
         .and_return(successful_response)
-      expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', previous_version: 33)
+      expect(Services.publishing_api).to receive(:publish).with(content_id, nil, previous_version: 33)
       expect(Services.publishing_api).to receive(:patch_links).with(content_id, links: { 'some' => 'linked_data' })
 
       PublishingAPINotifier.new(document).notify
@@ -28,7 +28,7 @@ describe PublishingAPINotifier do
       it "updates and publishes the document, but doesn't update the links" do
         expect(Services.publishing_api).to receive(:put_content).with(content_id, document_hash)
           .and_return(successful_response)
-        expect(Services.publishing_api).to receive(:publish).with(content_id, 'major', previous_version: 33)
+        expect(Services.publishing_api).to receive(:publish).with(content_id, nil, previous_version: 33)
         expect(Services.publishing_api).to_not receive(:patch_links)
 
         PublishingAPINotifier.new(document).notify(update_links: false)

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -13,7 +13,7 @@ describe 'manual sections resource' do
 
   it 'confirms update of the manual section' do
     stub_publishing_api_put_content(maximal_section_content_id, {}, body: { version: 788 })
-    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788 }.to_json)
+    stub_publishing_api_publish(maximal_section_content_id, { update_type: nil, previous_version: 788 }.to_json)
     stub_any_rummager_post
     stub_publishing_api_get_links(maximal_section_content_id)
     stub_put_default_organisation(maximal_section_content_id)
@@ -30,7 +30,7 @@ describe 'manual sections resource' do
 
   it 'errors if the Accept header is not application/json' do
     stub_publishing_api_put_content(maximal_section_content_id, {}, body: { version: 12 })
-    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 12 }.to_json)
+    stub_publishing_api_publish(maximal_section_content_id, { update_type: nil, previous_version: 12 }.to_json)
     stub_any_rummager_post
     stub_publishing_api_get_links(maximal_section_content_id)
     stub_put_default_organisation(maximal_section_content_id)
@@ -76,7 +76,7 @@ describe 'manual sections resource' do
 
   it 'returns the status code from the Publishing API response, not Rummager' do
     stub_publishing_api_put_content(maximal_section_content_id, {}, body: { version: 788 }) # This returns 200
-    stub_publishing_api_publish(maximal_section_content_id, { update_type: 'minor', previous_version: 788 }.to_json)
+    stub_publishing_api_publish(maximal_section_content_id, { update_type: nil, previous_version: 788 }.to_json)
     stub_any_rummager_post # This returns 202, as it does in Production
     stub_publishing_api_get_links(maximal_section_content_id)
     stub_put_default_organisation(maximal_section_content_id)

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -13,14 +13,13 @@ describe 'manuals resource' do
     stub_any_rummager_post
     stub_publishing_api_get_links(maximal_manual_content_id)
     stub_put_default_organisation(maximal_manual_content_id)
-
     put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
     expect(response.status).to eq(200)
     expect(response.headers['Content-Type']).to include('application/json')
 
     assert_publishing_api_put_content(maximal_manual_content_id, maximal_manual_for_publishing_api)
-    assert_publishing_api_publish(maximal_manual_content_id, update_type: 'major')
+    assert_publishing_api_publish(maximal_manual_content_id, update_type: nil)
     assert_rummager_posted_item(maximal_manual_for_rummager)
     expect(response.headers['Location']).to include(maximal_manual_url)
     expect(response.body).to include(maximal_manual_url)

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -64,7 +64,7 @@ describe "validation" do
         stub_publishing_api_get_links(content_id)
         stub_put_default_organisation(content_id)
 
-        stub_publishing_api_publish(content_id, { update_type: 'minor', previous_version: 22 }.to_json)
+        stub_publishing_api_publish(content_id, { update_type: nil, previous_version: 22 }.to_json)
         stub_any_rummager_post
 
         manual = valid_manual

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -3,6 +3,7 @@ module PublishingApiDataHelpers
     {
       "base_path" => "/hmrc-internal-manuals/employment-income-manual",
       "locale" => "en",
+      "update_type" => "major",
       "document_type" => "hmrc_manual",
       "schema_name" => "hmrc_manual",
       "title" => "Employment Income Manual",


### PR DESCRIPTION
We are deprecating sending the `update_type` in publish requests made to the Publishing API, and now expect clients to send `update_type` in PUT requests instead.  We upgrade `gds-api-adapters` to bring this app up to date with the new expected behaviour.  Also, in this app we are currently passing 3 params to publish, so we must continue to send all 3 arguments until `update_type` is fully deprecated, hence why we change it to `nil` in the meantime.

https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk