### PR TITLE
Include update_type in PublishingAPISection

### DIFF
--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -24,7 +24,7 @@ class PublishingAPISection
 
   def to_h
     @_to_h ||= begin
-      enriched_data = @section_attributes.except('content_id', 'update_type').deep_dup.merge(base_path: base_path,
+      enriched_data = @section_attributes.except('content_id').deep_dup.merge(base_path: base_path,
         document_type: SECTION_FORMAT,
         schema_name: SECTION_FORMAT,
         publishing_app: 'hmrc-manuals-api',

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -63,6 +63,7 @@ module PublishingApiDataHelpers
     {
       "base_path" => "/hmrc-internal-manuals/employment-income-manual/12345",
       "document_type" => "hmrc_manual_section",
+      "update_type" => "minor",
       "schema_name" => "hmrc_manual_section",
       "locale" => "en",
       "title" => "A section on a part of employment income",


### PR DESCRIPTION
https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk