### PR TITLE
Update InContentStoreValidator to validate on schema_name

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -24,8 +24,8 @@ class PublishingAPIManual
   def to_h
     @_to_h ||= begin
       enriched_data = @manual_attributes.except('content_id').deep_dup.merge(base_path: base_path,
-        document_type: MANUAL_FORMAT,
-        schema_name: MANUAL_FORMAT,
+        document_type: MANUAL_DOCUMENT_TYPE,
+        schema_name: MANUAL_SCHEMA_NAME,
         publishing_app: 'hmrc-manuals-api',
         rendering_app: 'manuals-frontend',
         routes: [

--- a/app/models/publishing_api_redirected_section.rb
+++ b/app/models/publishing_api_redirected_section.rb
@@ -38,6 +38,7 @@ class PublishingAPIRedirectedSection
           destination: redirect_to_location
         }
       ],
+      update_type: update_type
     }
   end
 

--- a/app/models/publishing_api_redirected_section.rb
+++ b/app/models/publishing_api_redirected_section.rb
@@ -8,7 +8,7 @@ class PublishingAPIRedirectedSection
   validates :manual_slug, :section_slug, :destination_manual_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates :destination_section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }, allow_nil: true
   validates_with InContentStoreValidator,
-    format: SECTION_FORMAT,
+    schema_name: SECTION_SCHEMA_NAME,
     content_store: Services.content_store,
     unless: -> {
       errors[:manual_slug].present? ||

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -56,7 +56,7 @@ class PublishingAPIRemovedManual
   def save!
     raise ValidationError, "manual to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = PublishingAPINotifier.new(self).notify(update_links: false)
-    Services.rummager.delete_document(MANUAL_FORMAT, base_path)
+    Services.rummager.delete_document(MANUAL_DOCUMENT_TYPE, base_path)
     publishing_api_response
   end
 end

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -7,7 +7,7 @@ class PublishingAPIRemovedManual
 
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
-    format: MANUAL_FORMAT,
+    schema_name: MANUAL_SCHEMA_NAME,
     content_store: Services.content_store,
     unless: -> { errors[:slug].present? }
 

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -52,7 +52,7 @@ class PublishingAPIRemovedSection
   def save!
     raise ValidationError, "manual section to remove is invalid #{errors.full_messages.to_sentence}" unless valid?
     publishing_api_response = PublishingAPINotifier.new(self).notify(update_links: false)
-    Services.rummager.delete_document(SECTION_FORMAT, base_path)
+    Services.rummager.delete_document(SECTION_DOCUMENT_TYPE, base_path)
     publishing_api_response
   end
 end

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -7,7 +7,7 @@ class PublishingAPIRemovedSection
 
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
-    format: SECTION_FORMAT,
+    schema_name: SECTION_SCHEMA_NAME,
     content_store: Services.content_store,
     unless: -> { errors[:manual_slug].present? || errors[:section_slug].present? }
 

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -25,8 +25,8 @@ class PublishingAPISection
   def to_h
     @_to_h ||= begin
       enriched_data = @section_attributes.except('content_id').deep_dup.merge(base_path: base_path,
-        document_type: SECTION_FORMAT,
-        schema_name: SECTION_FORMAT,
+        document_type: SECTION_DOCUMENT_TYPE,
+        schema_name: SECTION_SCHEMA_NAME,
         publishing_app: 'hmrc-manuals-api',
         rendering_app: 'manuals-frontend',
         routes: [{ path: PublishingAPISection.base_path(@manual_slug, @section_slug), type: :exact }],

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -12,7 +12,7 @@ class RummagerManual < RummagerBase
   def to_h
     {
       'content_id' => @content_id,
-      'content_store_document_type' => MANUAL_FORMAT,
+      'content_store_document_type' => MANUAL_DOCUMENT_TYPE,
       'description' => @publishing_api_manual['description'],
       'format' => MANUAL_FORMAT,
       'indexable_content' => nil,

--- a/app/models/rummager_manual.rb
+++ b/app/models/rummager_manual.rb
@@ -14,7 +14,7 @@ class RummagerManual < RummagerBase
       'content_id' => @content_id,
       'content_store_document_type' => MANUAL_DOCUMENT_TYPE,
       'description' => @publishing_api_manual['description'],
-      'format' => MANUAL_FORMAT,
+      'format' => MANUAL_SCHEMA_NAME,
       'indexable_content' => nil,
       'latest_change_note' => latest_change_note,
       'link' => id,
@@ -26,7 +26,7 @@ class RummagerManual < RummagerBase
   end
 
   def save!
-    SendToRummagerWorker.perform_async(MANUAL_FORMAT, self.id, self.to_h)
+    SendToRummagerWorker.perform_async(MANUAL_DOCUMENT_TYPE, self.id, self.to_h)
   end
 
 private

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -24,7 +24,7 @@ class RummagerSection < RummagerBase
   def to_h
     {
       'content_id' => @content_id,
-      'content_store_document_type' => SECTION_FORMAT,
+      'content_store_document_type' => SECTION_DOCUMENT_TYPE,
       'description' => @publishing_api_section['description'],
       'format' => SECTION_FORMAT,
       'hmrc_manual_section_id' => section_id,

--- a/app/models/rummager_section.rb
+++ b/app/models/rummager_section.rb
@@ -26,7 +26,7 @@ class RummagerSection < RummagerBase
       'content_id' => @content_id,
       'content_store_document_type' => SECTION_DOCUMENT_TYPE,
       'description' => @publishing_api_section['description'],
-      'format' => SECTION_FORMAT,
+      'format' => SECTION_SCHEMA_NAME,
       'hmrc_manual_section_id' => section_id,
       'indexable_content' => body_without_html,
       'link' => id,
@@ -39,12 +39,12 @@ class RummagerSection < RummagerBase
   end
 
   def save!
-    SendToRummagerWorker.perform_async(SECTION_FORMAT, self.id, self.to_h)
+    SendToRummagerWorker.perform_async(SECTION_DOCUMENT_TYPE, self.id, self.to_h)
   end
 
   def self.search_query(manual_path, start = 0, count = 1000)
     {
-      'filter_format' => SECTION_FORMAT,
+      'filter_format' => SECTION_SCHEMA_NAME,
       'filter_organisations' => GOVUK_HMRC_SLUG,
       'filter_manual' => manual_path,
       'count' => count,

--- a/app/validators/in_content_store_validator.rb
+++ b/app/validators/in_content_store_validator.rb
@@ -1,17 +1,17 @@
 class InContentStoreValidator < ActiveModel::Validator
-  attr_reader :format, :content_store
+  attr_reader :schema_name, :content_store
   def initialize(options = {})
     super
-    raise "Must provide format and content_store options to the validator" unless options[:format] && options[:content_store]
-    raise 'Can\'t provide "gone" as a format to the validator' if options[:format] == 'gone'
-    @format = options[:format]
+    raise "Must provide schema_name and content_store options to the validator" unless options[:schema_name] && options[:content_store]
+    raise 'Can\'t provide "gone" as a schema_name to the validator' if options[:schema_name] == 'gone'
+    @schema_name = options[:schema_name]
     @content_store = options[:content_store]
   end
 
   def validate(record)
     content_item = fetch_content_item(record)
-    if content_item["format"] != format
-      record.errors.add(:base, wrong_format_message(record, content_item))
+    if content_item["schema_name"] != schema_name
+      record.errors.add(:base, wrong_schema_name_message(record, content_item))
     end
   rescue GdsApi::HTTPNotFound
     record.errors.add(:base, missing_message(record, content_item))
@@ -33,7 +33,7 @@ private
     'Exists in the content store, but is already "gone"'
   end
 
-  def wrong_format_message(_record, content_item)
-    %{Exists in the content store, but is not a "#{format} (it's a "#{content_item['format']}"')"}
+  def wrong_schema_name_message(_record, content_item)
+    %{Exists in the content store, but is not a "#{schema_name}" schema (it's a "#{content_item['schema_name']}" schema)"}
   end
 end

--- a/app/workers/send_to_rummager_worker.rb
+++ b/app/workers/send_to_rummager_worker.rb
@@ -1,7 +1,7 @@
 class SendToRummagerWorker
   include Sidekiq::Worker
 
-  def perform(format, id, attributes)
-    Services.rummager.add_document(format, id, attributes)
+  def perform(document_type, id, attributes)
+    Services.rummager.add_document(document_type, id, attributes)
   end
 end

--- a/config/initializers/document_type.rb
+++ b/config/initializers/document_type.rb
@@ -1,0 +1,2 @@
+MANUAL_DOCUMENT_TYPE = 'hmrc_manual'
+SECTION_DOCUMENT_TYPE = 'hmrc_manual_section'

--- a/config/initializers/formats.rb
+++ b/config/initializers/formats.rb
@@ -1,2 +1,0 @@
-MANUAL_FORMAT = 'hmrc_manual'
-SECTION_FORMAT = 'hmrc_manual_section'

--- a/config/initializers/schema_names.rb
+++ b/config/initializers/schema_names.rb
@@ -1,0 +1,2 @@
+MANUAL_SCHEMA_NAME = 'hmrc_manual'
+SECTION_SCHEMA_NAME = 'hmrc_manual_section'

--- a/lib/sections_checker.rb
+++ b/lib/sections_checker.rb
@@ -8,9 +8,9 @@ class SectionsChecker
 
     children = child_sections(item)
 
-    if item['format'] == MANUAL_FORMAT
+    if item['schema_name'] == MANUAL_SCHEMA_NAME
       check_children_of_manual(item, children)
-    elsif item['format'] == SECTION_FORMAT
+    elsif item['schema_name'] == SECTION_SCHEMA_NAME
       check_children_of_section(item, children)
     end
   end

--- a/spec/lib/sections_checker_spec.rb
+++ b/spec/lib/sections_checker_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe SectionsChecker do
   def hmrc_manual_content_item_for_base_path(base_path, child_section_groups: [])
     item = content_item_for_base_path(base_path)
     item.merge(
-      "format" => MANUAL_FORMAT,
+      "schema_name" => MANUAL_SCHEMA_NAME,
       "details" => item["details"].merge(
         "child_section_groups" => child_section_groups
       )
@@ -355,7 +355,7 @@ RSpec.describe SectionsChecker do
   def hmrc_manual_section_content_item_for_base_path(base_path, child_section_groups: [], breadcrumbs: [], manual_base_path: "")
     item = content_item_for_base_path(base_path)
     item.merge(
-      "format" => SECTION_FORMAT,
+      "schema_name" => SECTION_SCHEMA_NAME,
       "details" => item["details"].merge(
         "child_section_groups" => child_section_groups,
         "breadcrumbs" => breadcrumbs,

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -139,6 +139,6 @@ describe PublishingAPIRedirectedSection do
   end
 
   def hmrc_manual_section_content_item_for_base_path(base_path)
-    content_item_for_base_path(base_path).merge("format" => SECTION_FORMAT)
+    content_item_for_base_path(base_path).merge("schema_name" => SECTION_SCHEMA_NAME)
   end
 end

--- a/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
@@ -100,6 +100,6 @@ describe PublishingAPIRedirectedSectionToParentManual do
   end
 
   def hmrc_manual_section_content_item_for_base_path(base_path)
-    content_item_for_base_path(base_path).merge("format" => SECTION_FORMAT)
+    content_item_for_base_path(base_path).merge("schema_name" => SECTION_SCHEMA_NAME)
   end
 end

--- a/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
@@ -35,7 +35,7 @@ describe PublishingAPIRedirectedSectionToParentManual do
         expect(subject).to be_valid
       end
 
-      it 'is invalid when the slugs represent any other format piece of content' do
+      it 'is invalid when the slugs represent a piece of content with any other schema_name' do
         content_store_has_item(section_path)
         expect(subject).not_to be_valid
       end

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -181,6 +181,6 @@ describe PublishingAPIRemovedManual do
   end
 
   def hmrc_manual_content_item_for_base_path(base_path)
-    content_item_for_base_path(base_path).merge("format" => MANUAL_FORMAT)
+    content_item_for_base_path(base_path).merge("schema_name" => MANUAL_SCHEMA_NAME)
   end
 end

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -34,7 +34,7 @@ describe PublishingAPIRemovedManual do
         expect(subject).to be_valid
       end
 
-      it 'is invalid when the slug represents any other format piece of content' do
+      it 'is invalid when the slug represents a piece of content with any other schema_name' do
         content_store_has_item(manual_path)
         expect(subject).not_to be_valid
       end

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -59,7 +59,7 @@ describe PublishingAPIRemovedSection do
         expect(subject).to be_valid
       end
 
-      it 'is invalid when the slugs represent any other format piece of content' do
+      it 'is invalid when the slugs represents a piece of content with any other schema_name' do
         content_store_has_item(section_path)
         expect(subject).not_to be_valid
       end

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -143,6 +143,6 @@ describe PublishingAPIRemovedSection do
   end
 
   def hmrc_manual_section_content_item_for_base_path(base_path)
-    content_item_for_base_path(base_path).merge("format" => SECTION_FORMAT)
+    content_item_for_base_path(base_path).merge("schema_name" => SECTION_SCHEMA_NAME)
   end
 end

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -155,6 +155,7 @@ module PublishingApiDataHelpers
           'destination' => "/hmrc-internal-manuals/#{dest_manual_slug}/#{dest_section_slug}"
         }
       ],
+      'update_type' => 'major'
     }
   end
 
@@ -171,6 +172,7 @@ module PublishingApiDataHelpers
           'destination' => "/hmrc-internal-manuals/#{dest_manual_slug}"
         }
       ],
+      'update_type' => 'major'
     }
   end
 
@@ -187,6 +189,7 @@ module PublishingApiDataHelpers
           'destination' => "/hmrc-internal-manuals/#{manual_slug}"
         }
       ],
+      'update_type' => 'major'
     }
   end
 end


### PR DESCRIPTION
I found that `InContentStoreValidator`was validating on `format`, however this has been deprecated in `govuk_content_schemas` (see https://github.com/alphagov/govuk-content-schemas/pull/620).  This meant that when attempting to redirect an HMRC manual section, the given section would be considered invalid as it has no format.  This updates `InContentStoreValidator` to validate against `schema_name` instead.  The formats initializer has also been removed as it has been replaced by a schema_name initializer.

TO DO:
- [x] Test redirecting an HMRC manual section on integration

https://trello.com/c/v2BJD3ER/1010-8-unpublish-sections-of-hmrc-manuals