### PR TITLE
Set the primary organisation for HMRC Manuals

### DIFF
--- a/app/models/links_builder.rb
+++ b/app/models/links_builder.rb
@@ -1,4 +1,6 @@
 class LinksBuilder
+  HMRC_CONTENT_ID = "6667cce2-e809-4e21-ae09-cb0bdc1ddda3".freeze
+
   def initialize(content_id)
     @content_id = content_id
     @built_links = {}
@@ -11,6 +13,7 @@ class LinksBuilder
       @content_store_links = nil
     end
     set_organisation
+    set_primary_organisation
     @built_links
   end
 
@@ -20,8 +23,11 @@ private
     @built_links["organisations"] = if @content_store_links && @content_store_links["organisations"].present?
                                       @content_store_links["organisations"]
                                     else
-                                      # Use HMRC content ID to set organisation
-                                      ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+                                      [HMRC_CONTENT_ID]
                                     end
+  end
+
+  def set_primary_organisation
+    @built_links["primary_publishing_organisation"] = [HMRC_CONTENT_ID]
   end
 end

--- a/spec/models/links_builder_spec.rb
+++ b/spec/models/links_builder_spec.rb
@@ -7,6 +7,14 @@ describe LinksBuilder do
   describe "#build_links" do
     let(:content_id) { "document-uuid" }
 
+    it "add HMRC content id as primary_publishing_organisation" do
+      stub_publishing_api_get_links(content_id, body: { links: { "some_other_link" => "foo" } })
+      expect(LinksBuilder.new(content_id).build_links).to eq(
+        "organisations" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"],
+        "primary_publishing_organisation" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+      )
+    end
+
     context "document already has linked organisation" do
       before do
         stub_publishing_api_get_links(content_id, body: { links: { "organisations" => ["some-org-uuid"] } })
@@ -14,7 +22,8 @@ describe LinksBuilder do
 
       it "uses the existing organisation content ID" do
         expect(LinksBuilder.new(content_id).build_links).to eq(
-          "organisations" => ["some-org-uuid"]
+          "organisations" => ["some-org-uuid"],
+          "primary_publishing_organisation" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
         )
       end
     end
@@ -26,7 +35,8 @@ describe LinksBuilder do
 
       it "uses the default HMRC organisation content ID" do
         expect(LinksBuilder.new(content_id).build_links).to eq(
-          "organisations" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+          "organisations" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"],
+          "primary_publishing_organisation" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
         )
       end
     end
@@ -39,7 +49,8 @@ describe LinksBuilder do
 
       it "uses the default HMRC organisation content ID" do
         expect(LinksBuilder.new(content_id).build_links).to eq(
-          "organisations" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
+          "organisations" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"],
+          "primary_publishing_organisation" => ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"]
         )
       end
     end

--- a/spec/support/links_update_helper.rb
+++ b/spec/support/links_update_helper.rb
@@ -7,7 +7,8 @@ module LinksUpdateHelper
   def stub_put_default_organisation(content_id)
     stub_publishing_api_patch_links(
       content_id,
-      { links: { organisations: ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"] } }.to_json
+      { links: { organisations: ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"],
+        primary_publishing_organisation: ["6667cce2-e809-4e21-ae09-cb0bdc1ddda3"] } }.to_json
     )
   end
 end


### PR DESCRIPTION
[Trello: Set Primary Org for HMRC Manuals](https://trello.com/c/e2huaChd/333-3-set-primary-org-for-hmrc-manuals)

This card is to add primary organisation data for HMRC Manuals API,
so that it sends the primary organisation of "HMRC" whenever it
publishes to the Publishing API.

