### PR TITLE
Change Plek(rummager) to Plek(search)

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -11,7 +11,7 @@ module Services
   end
 
   def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.current.find('rummager'))
+    @rummager ||= GdsApi::Rummager.new(Plek.current.find('search'))
   end
 
   def self.content_store


### PR DESCRIPTION
For the migration to search-api we're going to re-target the 'search'
alias to search-api.

---

[Trello card](https://trello.com/c/yrq9hZmU/77-point-the-search-alias-to-search-api-if-rummager-is-disabled)