### PR TITLE
Add investment funds slug

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -80,7 +80,6 @@ KNOWN_MANUAL_SLUGS = %w{
   holding-and-movements-duty-stamps
   holding-and-movements-exports-shops
   holding-and-movements-financial-securities-assurance
-  italian-tax-stamps
   holding-and-movements-registered-excise-dealers
   holding-and-movements-warehousing
   holding-and-movements-owners-and-transporters
@@ -97,6 +96,7 @@ KNOWN_MANUAL_SLUGS = %w{
   international-manual
   introduction-to-administrative-co-operation-in-excise
   investment-funds
+  italian-tax-stamps
   labour-provider-operational-guidance
   landfill-tax-liability
   life-assurance

--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -96,6 +96,7 @@ KNOWN_MANUAL_SLUGS = %w{
   international-exchange-of-information
   international-manual
   introduction-to-administrative-co-operation-in-excise
+  investment-funds
   labour-provider-operational-guidance
   landfill-tax-liability
   life-assurance


### PR DESCRIPTION
Following a [zendesk tick](https://govuk.zendesk.com/agent/tickets/3679470) alerting us to a forthcoming Investment Funds manual, the slug has been added to the `known_manual_slugs` list.