### PR TITLE
Add slug for Help to Save technical manual

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -69,6 +69,7 @@ KNOWN_MANUAL_SLUGS = %w{
   general-insurance-manual
   guidance-real-estate-investment-trusts
   guidance-audit-customs-values
+  help-save-technical
   holding-and-movements-alcohol-strategy-subsidiary-records
   holding-and-movements-alcohol-strategy-accounts
   holding-and-movements-alcohol-strategy-audit-risk-and-percet


### PR DESCRIPTION
Adds the slug [requested by HMRC](https://govuk.zendesk.com/agent/tickets/3837578) - `help-save-technical` added to the manual slugs.