### PR TITLE
Replace govuk-lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,10 @@ group :development do
 end
 
 group :development, :test do
-  gem "govuk-lint"
   gem "pry-byebug"
   gem "rspec-collection_matchers", "~> 1.2"
   gem "rspec-rails", "~> 3.9"
+  gem "rubocop-govuk"
   gem "shoulda-matchers", "~> 4.1"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,11 +96,6 @@ GEM
       sanitize (~> 5)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -268,6 +263,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -279,11 +278,6 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -292,8 +286,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (4.1.2)
@@ -347,7 +339,6 @@ DEPENDENCIES
   gds-sso (~> 14.2)
   govspeak (~> 6.5)
   govuk-content-schema-test-helpers (~> 1.6)
-  govuk-lint
   govuk_app_config (~> 2.0)
   json-schema (~> 2.8)
   listen
@@ -357,6 +348,7 @@ DEPENDENCIES
   responders (~> 3.0)
   rspec-collection_matchers (~> 1.2)
   rspec-rails (~> 3.9)
+  rubocop-govuk
   shoulda-matchers (~> 4.1)
   simplecov (~> 0.17)
   simplecov-rcov (~> 0.2)
@@ -364,4 +356,4 @@ DEPENDENCIES
   webmock (~> 3.7)
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
-desc "Run govuk-lint with similar params to CI"
+desc "Run rubocop with similar params to CI"
 task "lint" do
-  sh "bundle exec govuk-lint-ruby --diff --format clang app spec lib"
+  sh "bundle exec rubocop --format clang app spec lib"
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk