### PR TITLE
Replace Rummager with Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See the [extended documentation](docs/extended_documentation.md) for details:
 
 ### Dependencies
 
-- [alphagov/rummager](https://github.com/alphagov/rummager): allows document sections to be retrieved
+- [alphagov/search-api](https://github.com/alphagov/search-api): allows document sections to be retrieved
 - [alphagov/publishing-api](https://github.com/alphagov/publishing-api): allows documents to be published to the Publishing queue
 
 ### Running the application

--- a/app/models/publishing_api_redirected_section_to_parent_manual.rb
+++ b/app/models/publishing_api_redirected_section_to_parent_manual.rb
@@ -3,10 +3,10 @@ class PublishingAPIRedirectedSectionToParentManual < PublishingAPIRedirectedSect
     super(manual_slug, section_slug, manual_slug)
   end
 
-  def self.from_rummager_result(rummager_result)
-    raise InvalidJSONError if rummager_result.blank? || rummager_result["link"].blank?
+  def self.from_search_api_result(search_api_result)
+    raise InvalidJSONError if search_api_result.blank? || search_api_result["link"].blank?
 
-    slugs = PublishingAPISection.extract_slugs_from_path(rummager_result["link"])
+    slugs = PublishingAPISection.extract_slugs_from_path(search_api_result["link"])
     new(slugs[:manual], slugs[:section])
   end
 end

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -18,7 +18,7 @@ class PublishingAPIRemovedManual
   end
 
   def sections
-    SectionRetriever.new(slug).sections_from_rummager.map do |section_json|
+    SectionRetriever.new(slug).sections_from_search_api.map do |section_json|
       PublishingAPIRemovedSection.from_rummager_result(section_json)
     end
   end

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -19,7 +19,7 @@ class PublishingAPIRemovedManual
 
   def sections
     SectionRetriever.new(slug).sections_from_search_api.map do |section_json|
-      PublishingAPIRemovedSection.from_rummager_result(section_json)
+      PublishingAPIRemovedSection.from_search_api_result(section_json)
     end
   end
 

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -13,10 +13,10 @@ class PublishingAPIRemovedSection
 
   attr_accessor :manual_slug, :section_slug
 
-  def self.from_rummager_result(rummager_result)
-    raise InvalidJSONError if rummager_result.blank? || rummager_result["link"].blank?
+  def self.from_search_api_result(search_api_result)
+    raise InvalidJSONError if search_api_result.blank? || search_api_result["link"].blank?
 
-    slugs = PublishingAPISection.extract_slugs_from_path(rummager_result["link"])
+    slugs = PublishingAPISection.extract_slugs_from_path(search_api_result["link"])
     new(slugs[:manual], slugs[:section])
   end
 

--- a/app/models/search_api_section.rb
+++ b/app/models/search_api_section.rb
@@ -1,4 +1,4 @@
-class RummagerSection
+class SearchApiSection
   GOVUK_HMRC_SLUG = "hm-revenue-customs".freeze
 
   def self.search_query(manual_path, start = 0, count = 1000)

--- a/lib/section_retriever.rb
+++ b/lib/section_retriever.rb
@@ -5,12 +5,12 @@ class SectionRetriever
     @manual_slug = manual_slug
   end
 
-  def sections_from_rummager
+  def sections_from_search_api
     sections = []
     search_response = nil
 
     loop do
-      new_query = rummager_section_query(start_index(search_response))
+      new_query = search_api_section_query(start_index(search_response))
 
       search_response = Services.search_api.search(new_query)
       sections += search_response["results"]
@@ -32,7 +32,7 @@ private
     end
   end
 
-  def rummager_section_query(start_index)
+  def search_api_section_query(start_index)
     RummagerSection.search_query(base_path, start_index)
   end
 

--- a/lib/section_retriever.rb
+++ b/lib/section_retriever.rb
@@ -12,7 +12,7 @@ class SectionRetriever
     loop do
       new_query = rummager_section_query(start_index(search_response))
 
-      search_response = Services.rummager.search(new_query)
+      search_response = Services.search_api.search(new_query)
       sections += search_response["results"]
       return sections if all_sections_retrieved?(sections, search_response)
     end

--- a/lib/section_retriever.rb
+++ b/lib/section_retriever.rb
@@ -33,7 +33,7 @@ private
   end
 
   def search_api_section_query(start_index)
-    RummagerSection.search_query(base_path, start_index)
+    SearchApiSection.search_query(base_path, start_index)
   end
 
   def base_path

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,5 +1,5 @@
 require "gds_api/publishing_api_v2"
-require "gds_api/rummager"
+require "gds_api/search"
 require "gds_api/content_store"
 
 module Services
@@ -10,8 +10,8 @@ module Services
     )
   end
 
-  def self.rummager
-    @rummager ||= GdsApi::Rummager.new(Plek.current.find("search"))
+  def self.search_api
+    @search_api ||= GdsApi::Search.new(Plek.current.find("search"))
   end
 
   def self.content_store

--- a/lib/tasks/redirect_sections.rake
+++ b/lib/tasks/redirect_sections.rake
@@ -40,7 +40,7 @@ task :redirect_all_hmrc_sections_to_parent_manual, [] => :environment do |_task,
   else
     manual_slug = slugs[0]
 
-    sections = SectionRetriever.new(manual_slug).sections_from_rummager.map do |json|
+    sections = SectionRetriever.new(manual_slug).sections_from_search_api.map do |json|
       PublishingAPIRedirectedSectionToParentManual.from_rummager_result(json)
     end
     puts "Redirecting #{sections.count} sections"

--- a/lib/tasks/redirect_sections.rake
+++ b/lib/tasks/redirect_sections.rake
@@ -41,7 +41,7 @@ task :redirect_all_hmrc_sections_to_parent_manual, [] => :environment do |_task,
     manual_slug = slugs[0]
 
     sections = SectionRetriever.new(manual_slug).sections_from_search_api.map do |json|
-      PublishingAPIRedirectedSectionToParentManual.from_rummager_result(json)
+      PublishingAPIRedirectedSectionToParentManual.from_search_api_result(json)
     end
     puts "Redirecting #{sections.count} sections"
     sections.each do |section|

--- a/spec/lib/section_retriever_spec.rb
+++ b/spec/lib/section_retriever_spec.rb
@@ -8,7 +8,7 @@ describe SectionRetriever do
       search_api_query = stub_request(:get, %r{/search.json})
         .to_return(body: no_manual_sections_rummager_json_result)
 
-      subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+      subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_search_api_result(json) }
 
       assert_requested search_api_query
     end
@@ -17,7 +17,7 @@ describe SectionRetriever do
       stub_request(:get, %r{/search.json})
         .to_return(body: two_manual_sections_rummager_json_result("some-manual-slug"))
 
-      sections = subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+      sections = subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_search_api_result(json) }
       expect(sections.size).to eq(2)
 
       expect(sections.first).to be_a PublishingAPIRemovedSection
@@ -34,7 +34,7 @@ describe SectionRetriever do
         .to_return(status: 503, body: '{"error":"arg!"}')
 
       expect {
-        subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+        subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_search_api_result(json) }
       }.to raise_error(GdsApi::BaseError)
     end
 

--- a/spec/lib/section_retriever_spec.rb
+++ b/spec/lib/section_retriever_spec.rb
@@ -6,7 +6,7 @@ describe SectionRetriever do
 
     it "asks Search API for all the hmrc manual sections under its slug" do
       search_api_query = stub_request(:get, %r{/search.json})
-        .to_return(body: no_manual_sections_rummager_json_result)
+        .to_return(body: no_manual_sections_search_api_json_result)
 
       subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_search_api_result(json) }
 
@@ -15,7 +15,7 @@ describe SectionRetriever do
 
     it "exposes each result from Search API as the specified Section type" do
       stub_request(:get, %r{/search.json})
-        .to_return(body: two_manual_sections_rummager_json_result("some-manual-slug"))
+        .to_return(body: two_manual_sections_search_api_json_result("some-manual-slug"))
 
       sections = subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_search_api_result(json) }
       expect(sections.size).to eq(2)
@@ -43,10 +43,10 @@ describe SectionRetriever do
 
       it "gets all sections when there is more than one page of results" do
         stub_request(:get, %r{/search.json?.+start=0})
-          .to_return(body: one_of_two_manual_sections_rummager_json_result("some-manual-slug"))
+          .to_return(body: one_of_two_manual_sections_search_api_json_result("some-manual-slug"))
 
         stub_request(:get, %r{/search.json?.+start=1})
-          .to_return(body: two_of_two_manual_sections_rummager_json_result("some-manual-slug"))
+          .to_return(body: two_of_two_manual_sections_search_api_json_result("some-manual-slug"))
 
         sections = subject.sections_from_search_api.map { |json| PublishingAPIRedirectedSectionToParentManual.from_search_api_result(json) }
         expect(sections.size).to eq(2)

--- a/spec/lib/section_retriever_spec.rb
+++ b/spec/lib/section_retriever_spec.rb
@@ -1,23 +1,23 @@
 require "rails_helper"
 
 describe SectionRetriever do
-  describe "#sections_from_rummager" do
+  describe "#sections_from_search_api" do
     subject(:section_retriever) { described_class.new("some-manual-slug") }
 
-    it "asks rummager for all the hmrc manual sections under its slug" do
-      rummager_query = stub_request(:get, %r{/search.json})
+    it "asks Search API for all the hmrc manual sections under its slug" do
+      search_api_query = stub_request(:get, %r{/search.json})
         .to_return(body: no_manual_sections_rummager_json_result)
 
-      subject.sections_from_rummager.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+      subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
 
-      assert_requested rummager_query
+      assert_requested search_api_query
     end
 
-    it "exposes each result from rummager as the specified Section type" do
+    it "exposes each result from Search API as the specified Section type" do
       stub_request(:get, %r{/search.json})
         .to_return(body: two_manual_sections_rummager_json_result("some-manual-slug"))
 
-      sections = subject.sections_from_rummager.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+      sections = subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
       expect(sections.size).to eq(2)
 
       expect(sections.first).to be_a PublishingAPIRemovedSection
@@ -29,12 +29,12 @@ describe SectionRetriever do
       expect(sections.last.section_slug).to eq("section-2")
     end
 
-    it "exposes the error from rummager if the rummager call fails" do
+    it "exposes the error from Search API if the Search API call fails" do
       stub_request(:get, %r{/search.json})
         .to_return(status: 503, body: '{"error":"arg!"}')
 
       expect {
-        subject.sections_from_rummager.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
+        subject.sections_from_search_api.map { |json| PublishingAPIRemovedSection.from_rummager_result(json) }
       }.to raise_error(GdsApi::BaseError)
     end
 
@@ -48,7 +48,7 @@ describe SectionRetriever do
         stub_request(:get, %r{/search.json?.+start=1})
           .to_return(body: two_of_two_manual_sections_rummager_json_result("some-manual-slug"))
 
-        sections = subject.sections_from_rummager.map { |json| PublishingAPIRedirectedSectionToParentManual.from_rummager_result(json) }
+        sections = subject.sections_from_search_api.map { |json| PublishingAPIRedirectedSectionToParentManual.from_rummager_result(json) }
         expect(sections.size).to eq(2)
 
         expect(sections.first).to be_a PublishingAPIRedirectedSectionToParentManual

--- a/spec/lib/section_retriever_spec.rb
+++ b/spec/lib/section_retriever_spec.rb
@@ -48,7 +48,7 @@ describe SectionRetriever do
         stub_request(:get, %r{/search.json?.+start=1})
           .to_return(body: two_of_two_manual_sections_rummager_json_result("some-manual-slug"))
 
-        sections = subject.sections_from_search_api.map { |json| PublishingAPIRedirectedSectionToParentManual.from_rummager_result(json) }
+        sections = subject.sections_from_search_api.map { |json| PublishingAPIRedirectedSectionToParentManual.from_search_api_result(json) }
         expect(sections.size).to eq(2)
 
         expect(sections.first).to be_a PublishingAPIRedirectedSectionToParentManual

--- a/spec/models/publishing_api_redirected_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_manual_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api_v2"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIRedirectedManual do
@@ -70,7 +70,7 @@ describe PublishingAPIRedirectedManual do
 
   describe "#save!" do
     include GdsApi::TestHelpers::PublishingApiV2
-    include GdsApi::TestHelpers::Rummager
+    include GdsApi::TestHelpers::Search
 
     before do
       content_item = hmrc_manual_section_content_item_for_base_path(subject.base_path)

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api_v2"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIRedirectedSection do
@@ -84,7 +84,7 @@ describe PublishingAPIRedirectedSection do
 
   describe "#save!" do
     include GdsApi::TestHelpers::PublishingApiV2
-    include GdsApi::TestHelpers::Rummager
+    include GdsApi::TestHelpers::Search
 
     before do
       content_item = hmrc_manual_section_content_item_for_base_path(subject.base_path)

--- a/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api_v2"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIRedirectedSectionToParentManual do
@@ -61,7 +61,7 @@ describe PublishingAPIRedirectedSectionToParentManual do
 
   describe "#save!" do
     include GdsApi::TestHelpers::PublishingApiV2
-    include GdsApi::TestHelpers::Rummager
+    include GdsApi::TestHelpers::Search
     include GdsApi::TestHelpers::ContentStore
     before do
       content_item = hmrc_manual_section_content_item_for_base_path(subject.base_path)

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -73,18 +73,18 @@ describe PublishingAPIRemovedManual do
   describe "#sections" do
     subject(:removed_manual) { described_class.new("some-manual-slug") }
 
-    it "asks rummager for all the hmrc manual sections under its slug" do
-      rummager_query = stub_request(:get, %r{/search.json})
-        .to_return(body: no_manual_sections_rummager_json_result)
+    it "asks Search API for all the hmrc manual sections under its slug" do
+      search_api_query = stub_request(:get, %r{/search.json})
+        .to_return(body: no_manual_sections_search_api_json_result)
 
       subject.sections
 
-      assert_requested rummager_query
+      assert_requested search_api_query
     end
 
-    it "exposes each result from rummager as a PublishingAPIRemovedSection" do
+    it "exposes each result from Search API as a PublishingAPIRemovedSection" do
       stub_request(:get, %r{/search.json})
-        .to_return(body: two_manual_sections_rummager_json_result("some-manual-slug"))
+        .to_return(body: two_manual_sections_search_api_json_result("some-manual-slug"))
 
       sections = subject.sections
       expect(sections.size).to eq(2)
@@ -98,7 +98,7 @@ describe PublishingAPIRemovedManual do
       expect(sections.last.section_slug).to eq("section-2")
     end
 
-    it "exposes the error from rummager if the rummager call fails" do
+    it "exposes the error from Search API if the Search API call fails" do
       stub_request(:get, %r{/search.json})
         .to_return(status: 503, body: '{"error":"arg!"}')
 
@@ -112,10 +112,10 @@ describe PublishingAPIRemovedManual do
 
       it "gets all sections when there is more than one page of results" do
         stub_request(:get, %r{/search.json?.+start=0})
-          .to_return(body: one_of_two_manual_sections_rummager_json_result("some-manual-slug"))
+          .to_return(body: one_of_two_manual_sections_search_api_json_result("some-manual-slug"))
 
         stub_request(:get, %r{/search.json?.+start=1})
-          .to_return(body: two_of_two_manual_sections_rummager_json_result("some-manual-slug"))
+          .to_return(body: two_of_two_manual_sections_search_api_json_result("some-manual-slug"))
 
         sections = subject.sections
         expect(sections.size).to eq(2)

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api_v2"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIRemovedManual do

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api_v2"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIRemovedSection do

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -4,11 +4,11 @@ require "gds_api/test_helpers/search"
 require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIRemovedSection do
-  describe ".from_rummager_result" do
+  describe ".from_search_api_result" do
     let(:rummager_json) { single_section_parsed_rummager_json_result("manual-slug", "section-slug") }
 
     it "extracts the manual and section slugs from the link attribute" do
-      section = described_class.from_rummager_result(rummager_json)
+      section = described_class.from_search_api_result(rummager_json)
       expect(section).to be_a described_class
       expect(section.manual_slug).to eq("manual-slug")
       expect(section.section_slug).to eq("section-slug")
@@ -16,13 +16,13 @@ describe PublishingAPIRemovedSection do
 
     it "raises an InvalidJSONError if the json object has no link attribute" do
       expect {
-        described_class.from_rummager_result(rummager_json.except("link"))
+        described_class.from_search_api_result(rummager_json.except("link"))
       }.to raise_error(InvalidJSONError)
     end
 
     it "raises an InvalidPathError if the link attribute cannot be used to extract slugs" do
       expect {
-        described_class.from_rummager_result(rummager_json.merge("link" => "/oh-my/what-a-hat/"))
+        described_class.from_search_api_result(rummager_json.merge("link" => "/oh-my/what-a-hat/"))
       }.to raise_error(InvalidPathError)
     end
   end

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -5,10 +5,10 @@ require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIRemovedSection do
   describe ".from_search_api_result" do
-    let(:rummager_json) { single_section_parsed_rummager_json_result("manual-slug", "section-slug") }
+    let(:search_api_json) { single_section_parsed_search_api_json_result("manual-slug", "section-slug") }
 
     it "extracts the manual and section slugs from the link attribute" do
-      section = described_class.from_search_api_result(rummager_json)
+      section = described_class.from_search_api_result(search_api_json)
       expect(section).to be_a described_class
       expect(section.manual_slug).to eq("manual-slug")
       expect(section.section_slug).to eq("section-slug")
@@ -16,13 +16,13 @@ describe PublishingAPIRemovedSection do
 
     it "raises an InvalidJSONError if the json object has no link attribute" do
       expect {
-        described_class.from_search_api_result(rummager_json.except("link"))
+        described_class.from_search_api_result(search_api_json.except("link"))
       }.to raise_error(InvalidJSONError)
     end
 
     it "raises an InvalidPathError if the link attribute cannot be used to extract slugs" do
       expect {
-        described_class.from_search_api_result(rummager_json.merge("link" => "/oh-my/what-a-hat/"))
+        described_class.from_search_api_result(search_api_json.merge("link" => "/oh-my/what-a-hat/"))
       }.to raise_error(InvalidPathError)
     end
   end

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 require "gds_api/test_helpers/publishing_api_v2"
-require "gds_api/test_helpers/rummager"
+require "gds_api/test_helpers/search"
 
 describe "validation" do
   include GdsApi::TestHelpers::PublishingApiV2
-  include GdsApi::TestHelpers::Rummager
+  include GdsApi::TestHelpers::Search
   include LinksUpdateHelper
 
   let(:headers) { { "Content-Type" => "application/json", "HTTP_AUTHORIZATION" => "Bearer 12345678" } }
@@ -56,7 +56,7 @@ describe "validation" do
         stub_put_default_organisation(content_id)
 
         stub_publishing_api_publish(content_id, { update_type: nil, previous_version: 22 }.to_json)
-        stub_any_rummager_post
+        stub_any_search_post
 
         manual = valid_manual
         manual["description"] = "![Manual](/path/to/image.png)"

--- a/spec/support/search_api_helpers.rb
+++ b/spec/support/search_api_helpers.rb
@@ -1,5 +1,5 @@
-module RummagerHelpers
-  def no_manual_sections_rummager_json_result
+module SearchApiHelpers
+  def no_manual_sections_search_api_json_result
     <<-JSON.strip_heredoc
       {
         "results":[],
@@ -11,7 +11,7 @@ module RummagerHelpers
     JSON
   end
 
-  def single_section_parsed_rummager_json_result(manual_slug, section_slug = "section-1")
+  def single_section_parsed_search_api_json_result(manual_slug, section_slug = "section-1")
     {
       "format" => "hmrc_manual_section",
       "link" => "/hmrc-internal-manuals/#{manual_slug}/#{section_slug}",
@@ -33,7 +33,7 @@ module RummagerHelpers
     }
   end
 
-  def two_manual_sections_rummager_json_result(manual_slug)
+  def two_manual_sections_search_api_json_result(manual_slug)
     <<-JSON.strip_heredoc
       {
         "results":[
@@ -84,7 +84,7 @@ module RummagerHelpers
     JSON
   end
 
-  def one_of_two_manual_sections_rummager_json_result(manual_slug)
+  def one_of_two_manual_sections_search_api_json_result(manual_slug)
     <<-JSON.strip_heredoc
       {
         "results":[
@@ -116,7 +116,7 @@ module RummagerHelpers
     JSON
   end
 
-  def two_of_two_manual_sections_rummager_json_result(manual_slug)
+  def two_of_two_manual_sections_search_api_json_result(manual_slug)
     <<-JSON.strip_heredoc
       {
         "results":[
@@ -149,4 +149,4 @@ module RummagerHelpers
   end
 end
 
-RSpec.configuration.include(RummagerHelpers)
+RSpec.configuration.include(SearchApiHelpers)


### PR DESCRIPTION
Rummager has been deprecated in favour of Search API, so this PR replaces use of Rummager with Search API.  Additionally, in order to avoid future confusion as Rummager drops out of common knowledge among GOV.UK developers, we replace references to Rummager in the code with Search API.