### PR TITLE
Disable CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   respond_to :json
 
+  skip_forgery_protection
+
   before_action :authenticate_user!
   before_action :check_content_type_header
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,19 +1,13 @@
 require_relative "boot"
 
 require "rails"
-# Pick the frameworks you want:
+
 require "active_model/railtie"
 require "active_job/railtie"
-# require "active_record/railtie"
-# require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-# require "action_mailbox/engine"
-# require "action_text/engine"
 require "action_view/railtie"
-# require "action_cable/engine"
 require "sprockets/railtie"
-# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -25,37 +19,14 @@ module HMRCManualsAPI
     config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    # Application configuration can go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded after loading
+    # the framework and any gems in your application.
 
     # We need to put this middleware back, after "rails-api" strips it out.
     # This middleware must be present, otherwise the "request_store" gem, which
     # is a dependency of "logstasher", falls over. It's not clear whether "request_store"
     # actually uses this middleware itself, but it references it in the railtie.
     config.middleware.insert_after(Rack::Runtime, Rack::MethodOverride)
-
-    # Disable Rack::Cache
-    config.action_dispatch.rack_cache = nil
-
-    # Enable per-form CSRF tokens. Pre Rails 5 had false.
-    config.action_controller.per_form_csrf_tokens = false
-
-    # Enable origin-checking CSRF mitigation. Pre Rails 5 had false.
-    config.action_controller.forgery_protection_origin_check = false
-
-    # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
-    # Pre Rails 5 had false.
-    ActiveSupport.to_time_preserves_timezone = false
-
-    # Make `form_with` generate non-remote forms.
-    config.action_view.form_with_generates_remote_forms = false
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,8 +27,9 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  # Enable request forgery protection in test environment.
+  # This is so the tests fail if CSRF protection is enabled by default.
+  config.action_controller.allow_forgery_protection = true
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
CSRF protection was accidentally re-enabled during the upgrade from Rails 5.1 to 6.0 because the setting was added to ActionController::Base and the protect_from_forgery line removed from ApplicationController.