### PR TITLE
Refactor config/routes.rb to use mapper DSL features

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,15 @@
 Rails.application.routes.draw do
   # This strips out Rails' default .json/.xml format file extensions.
-  with_options format: false do |r|
-    r.get "/", controller: "root", action: "index"
-    r.get "/documentation", controller: "root", action: "documentation"
-    r.get "/readme", to: redirect("/documentation")
-    r.get "/healthcheck", to: proc { [200, {}, %w[OK]] }
+  scope format: false do
+    get "/", to: "root#index"
+    get "/documentation", to: "root#documentation"
+    get "/readme", to: redirect("/documentation")
+    get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
-    # We need to override the controller and url helper here because rails is unhappy
-    # with the dash in 'hmrc-manuals'.
-    r.resources "hmrc-manuals", only: :update, controller: "manuals", as: "manuals" do
-      r.resources "sections", only: :update
+    scope only: :update do
+      resources :manuals, path: "hmrc-manuals" do
+        resources :sections
+      end
     end
   end
 end


### PR DESCRIPTION
There is no need to use with_options to set the format to false and the path option to resources allows us to override the url without having to reset all the url helper method names and controller names.

The output for `rake routes` is identical after this change.