### PR TITLE
Upgrade govspeak to 6.5.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,13 +95,13 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govspeak (6.5.5)
+    govspeak (6.5.6)
       actionview (>= 5.0, < 7)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (~> 21.4)
       htmlentities (~> 4)
       i18n (~> 0.7)
-      kramdown (~> 1.15.0)
+      kramdown (>= 2.3.0)
       nokogiri (~> 1.5)
       nokogumbo (~> 2)
       rinku (~> 2.0)
@@ -132,7 +132,8 @@ GEM
       addressable (>= 2.4)
     jwt (2.2.1)
     kgio (2.11.3)
-    kramdown (1.15.0)
+    kramdown (2.3.0)
+      rexml
     link_header (0.0.8)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -364,4 +365,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
This PR upgrades `govspeak` to version `6.5.6`, resolving [CVE-2020-14001](https://github.com/advisories/GHSA-mqm2-cgpr-p4m6).

Trello: https://trello.com/c/H49ZOsu1/972-update-all-govspeak-depenendencies-in-govuk-apps