### PR TITLE
Always print coverage after running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,5 @@ group :test do
   gem "ci_reporter_rspec"
   gem "govuk-content-schema-test-helpers"
   gem "simplecov", require: false
-  gem "simplecov-rcov", require: false
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,8 +302,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -358,7 +356,6 @@ DEPENDENCIES
   rubocop-govuk
   shoulda-matchers
   simplecov
-  simplecov-rcov
   uuidtools
   webmock
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,4 @@
 require "simplecov"
-require "simplecov-rcov"
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 SimpleCov.start "rails"
 
 RSpec.configure do |config|


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Note that the RCov formatter is optional, and it's still possible
to see a detailed web page of the coverage.