### PR TITLE
Point to rake runner and clarify slug format

### DIFF
--- a/docs/extended_documentation.md
+++ b/docs/extended_documentation.md
@@ -223,7 +223,7 @@ need a real token for the right environment.
 ## Managing manuals and sections with rake
 
 HMRC Manuals API contains [rake tasks](https://github.com/alphagov/hmrc-manuals-api/tree/master/lib/tasks)
-for removing manuals and sections and redirecting sections.
+for removing manuals and sections and redirecting sections. These can be run using the [rake Jenkins job](https://docs.publishing.service.gov.uk/manual/running-rake-tasks.html). Where the examples below require a slug as a parameter, this is the last part of the URL without a leading slash, for example given the URL 'https://www.gov.uk/hmrc-internal-manuals/guidance-audit-customs-values' the slug would be 'guidance-audit-customs-values'
 
 ### Redirect a section back to the parent manual
 


### PR DESCRIPTION
It is often unclear whether a slug needed in a rake task should include everything after gov.uk or any leading slashes. This gives a concrete example to avoid trial and error attempts, and also points to the documentation for running rake tasks on different environments without using the command line.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
