### PR TITLE
Remove redundant Jenkinsfile config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject(
-    rubyLintDiff: false,
-    brakeman: true
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
The RubyLintDiff argument no longer has any affect and brakeman defaults to true.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
