### PR TITLE
Revise tech docs in README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ manual consists of two document types: the manual itself and manual sections.
 
 - **Section**: Sections can contain sub-sections and/or a content body. See [Adding or updating a section](docs/extended_documentation.md#adding-or-updating-a-manual-section) for more details.
 
-<a name="adding-a-new-slug"></a>
-## Adding a new slug
-
-Before adding a new manual through the api, the slug for the manual must be added to [/config/initializers/known_manual_slugs.rb](config/initializers/known_manual_slugs.rb) and the application re-deployed.
-
-The workflow for this is likely to be initiated by a Zendesk ticket raised by HMRC with the new slug. A developer can
-then add the slug and re-deploy the application and inform HMRC that the slug is ready to be published against.
-
 ## Technical documentation
 
 This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
@@ -33,6 +25,15 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 ```sh
 bundle exec rspec
 ```
+
+<a name="adding-a-new-slug"></a>
+### Adding a new slug
+
+Before adding a new manual through the API, the slug for the manual must be added to [/config/initializers/known_manual_slugs.rb](config/initializers/known_manual_slugs.rb) and the application re-deployed.
+
+The workflow for this is likely to be initiated by a Zendesk ticket raised by HMRC with
+the new slug. A developer can then add the slug and re-deploy the application and
+inform HMRC that the slug is ready to be published against.
 
 ## Manuals and decisions
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@ This app provides URLs for pushing HMRC manuals to the GOV.UK Publishing API.
 
 Before adding a new manual through the api, the slug for the manual must be added to [/config/initializers/known_manual_slugs.rb](config/initializers/known_manual_slugs.rb) and the application re-deployed.
 
-The workflow for this is likely to be initiated by a zendesk ticket raised by HMRC with the new slug. A developer can
+The workflow for this is likely to be initiated by a Zendesk ticket raised by HMRC with the new slug. A developer can
 then add the slug and re-deploy the application and inform HMRC that the slug is ready to be published against.
 
 ## Technical documentation
+
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
+
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
+
+**Use GOV.UK Docker to run any commands that follow.**
 
 Provides an API for a system built by HMRC to publish tax manuals onto GOV.UK. In many ways it is analogous to a backend/admin app for publishing on GOV.UK. Content which passes validation and checks for unsanitary content is submitted to the GOV.UK Publishing API application. The application does not have a database itself. An HMRC manual consists of two document types: the manual itself and manual sections.
 
@@ -31,24 +37,15 @@ See the [extended documentation](docs/extended_documentation.md) for details:
 - [Markup](docs/extended_documentation.md#markup)
 - [Manual Tags](docs/extended_documentation.md#manual-tags)
 - [Removing published manuals](docs/extended_documentation.md#removing-published-manuals)
-- [Testing publishing in the GOVUK dev vm](docs/extended_documentation.md#testing-publishing-in-the-govuk-development-vm)
+- [Testing publishing in GOV.UK Docker](docs/extended_documentation.md#testing-publishing-in-govuk-docker)
 - [Managing manuals and sections with rake](docs/extended_documentation.md#managing-manuals-and-sections-with-rake)
-
-### Running the application
-
-`./startup.sh`
-
-This runs `bundle install` to install dependencies and runs the app on port `3071`.
-
-When using the GOV.UK development VM use `bowl hmrc-manuals-api` in the Dev VM `development` directory. The app will be available at http://hmrc-manuals-api.dev.gov.uk/.
+- [Responses to PUT requests](docs/extended_documentation.md#possible-responses-to-put-requests)
 
 ### Running the test suite
 
-`bundle exec rake`
-
-### Example API output
-
-[Responses to PUT requests](docs/extended_documentation.md#possible-responses-to-put-requests)
+```sh
+bundle exec rspec
+```
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # HMRC Manuals API
 
-This app provides URLs for pushing HMRC manuals to the GOV.UK Publishing API.
+Provides an API for a system built by HMRC to publish tax manuals onto GOV.UK. In many
+ways it is analogous to a backend/admin app for publishing on GOV.UK. Content which
+passes validation and checks for unsanitary content is submitted to the GOV.UK
+Publishing API application. The application does not have a database itself. An HMRC
+manual consists of two document types: the manual itself and manual sections.
 
 ## Nomenclature
 
@@ -23,8 +27,6 @@ This is a Ruby on Rails app, and should follow [our Rails app conventions](https
 You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
 **Use GOV.UK Docker to run any commands that follow.**
-
-Provides an API for a system built by HMRC to publish tax manuals onto GOV.UK. In many ways it is analogous to a backend/admin app for publishing on GOV.UK. Content which passes validation and checks for unsanitary content is submitted to the GOV.UK Publishing API application. The application does not have a database itself. An HMRC manual consists of two document types: the manual itself and manual sections.
 
 See the [extended documentation](docs/extended_documentation.md) for details:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 
 **Use GOV.UK Docker to run any commands that follow.**
 
+### Running the test suite
+
+```sh
+bundle exec rspec
+```
+
+## Manuals and decisions
+
 See the [extended documentation](docs/extended_documentation.md) for details:
 
 - [Connecting to the API](docs/extended_documentation.md#connecting-to-the-api)
@@ -42,12 +50,6 @@ See the [extended documentation](docs/extended_documentation.md) for details:
 - [Testing publishing in GOV.UK Docker](docs/extended_documentation.md#testing-publishing-in-govuk-docker)
 - [Managing manuals and sections with rake](docs/extended_documentation.md#managing-manuals-and-sections-with-rake)
 - [Responses to PUT requests](docs/extended_documentation.md#possible-responses-to-put-requests)
-
-### Running the test suite
-
-```sh
-bundle exec rspec
-```
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,6 @@ See the [extended documentation](docs/extended_documentation.md) for details:
 - [Testing publishing in the GOVUK dev vm](docs/extended_documentation.md#testing-publishing-in-the-govuk-development-vm)
 - [Managing manuals and sections with rake](docs/extended_documentation.md#managing-manuals-and-sections-with-rake)
 
-### Dependencies
-
-- [alphagov/search-api](https://github.com/alphagov/search-api): allows document sections to be retrieved
-- [alphagov/publishing-api](https://github.com/alphagov/publishing-api): allows documents to be published to the Publishing queue
-
 ### Running the application
 
 `./startup.sh`
@@ -50,10 +45,6 @@ When using the GOV.UK development VM use `bowl hmrc-manuals-api` in the Dev VM `
 ### Running the test suite
 
 `bundle exec rake`
-
-### Any deviations from idiomatic Rails/Go etc.
-
-The application does not have a database itself, it sends on requests to the Publishing API.
 
 ### Example API output
 

--- a/docs/extended_documentation.md
+++ b/docs/extended_documentation.md
@@ -195,7 +195,7 @@ $ cd /var/apps/hmrc-manuals-api
 $ sudo -u deploy govuk_setenv hmrc-manuals-api bundle exec rake remove_hmrc_manuals[slug-to-remove-1,slug-to-remove-2,...,slug-to-remove-n]
 ```
 
-## Testing publishing in the GOV.UK development VM
+## Testing publishing in GOV.UK Docker
 
 You can use the JSON examples of requests for testing publishing in development,
 for example with cURL from the root directory of the repository:
@@ -218,7 +218,6 @@ http PUT http://hmrc-manuals-api.dev.gov.uk/hmrc-manuals/test-manual \
 In development mode the API doesn't require a valid bearer token; any value is
 accepted. To test publishing to our Integration or Staging environments you would
 need a real token for the right environment.
-
 
 ## Managing manuals and sections with rake
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bundle install
-bundle exec rails s -p 3071


### PR DESCRIPTION
This makes several changes to refactor and revise the README to better match our other repos. The end result follows the pattern established in https://github.com/alphagov/content-publisher/pull/2257. See the commit messages for more details.

[Trello Card](https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh)