### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
     get "/readme", to: redirect("/documentation")
     get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
+    get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+    get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+
     scope only: :update do
       resources :manuals, path: "hmrc-manuals" do
         resources :sections


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
