### PR TITLE
Increasing the publishing api timeout duration

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -7,6 +7,7 @@ module Services
     @publishing_api ||= GdsApi::PublishingApi.new(
       Plek.new.find("publishing-api"),
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
+      timeout: 10,
     )
   end
 


### PR DESCRIPTION
HMRC developers are reporting intermittent 504 errors when publishing large manuals. [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4712404)

I've replicated this error using postman to send a large payload (provided by the HMRC devs).  

```
jessicajones@ec2-integration-blue-backend-ip-10-1-5-36:/var/log/nginx$ tail -n 100 hmrc-manuals-api-error.log
2021/09/28 13:17:31 [error] 5422#5422: *279370960 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 10.1.2.15, server: hmrc-manuals-api, request: "PUT /hmrc-manuals/foo HTTP/1.1", upstream: "http://127.0.0.1:3071/hmrc-manuals/foo", host: "hmrc-manuals-api.integration.publishing.service.gov.uk"
2021/09/28 13:34:00 [error] 15379#15379: *279378309 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 10.1.3.6, server: hmrc-manuals-api, request: "PUT /hmrc-manuals/bar HTTP/1.1", upstream: "http://127.0.0.1:3071/hmrc-manuals/bar", host: "hmrc-manuals-api.integration.publishing.service.gov.uk"
```

Increasing the timeout duration for publishing api has resolved this error when testing on integration.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
