### PR TITLE
Use unicorn to allow concurrent connections

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails s -p 3071
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3071}


### PR DESCRIPTION
The app is currently using `rails s` as a server. This does not allow concurrent connections.

In the event that a request is slow, it is possible the next request will not be possible and nginx will timeout.

By switching to use `govuk_unicorn`, we can accept two concurrent connections which may help alleviate the issue.

[Trello card](https://trello.com/c/ypeU8K74)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️