### PR TITLE
Add uncertain-tax-treatments-by-large-businesses-manual to known slugs

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -156,6 +156,7 @@ KNOWN_MANUAL_SLUGS = %w[
   tonnage-tax-manual
   trust-registration-service-manual
   trusts-settlements-and-estates-manual
+  uncertain-tax-treatments-by-large-businesses-manual
   vat-accounting
   vat-agricultural-flat-rate-scheme
   vat-annual-accounting-system


### PR DESCRIPTION
Add uncertain-tax-treatments-by-large-businesses-manual to known slugs as requested by HMRC