### PR TITLE
Change rendering app to government-frontend

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -28,7 +28,7 @@ class PublishingAPIManual
         document_type: MANUAL_DOCUMENT_TYPE,
         schema_name: MANUAL_SCHEMA_NAME,
         publishing_app: "hmrc-manuals-api",
-        rendering_app: "manuals-frontend",
+        rendering_app: "government-frontend",
         routes: [
           { path: base_path, type: :exact },
           { path: updates_path, type: :exact },

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -29,7 +29,7 @@ class PublishingAPISection
         document_type: SECTION_DOCUMENT_TYPE,
         schema_name: SECTION_SCHEMA_NAME,
         publishing_app: "hmrc-manuals-api",
-        rendering_app: "manuals-frontend",
+        rendering_app: "government-frontend",
         routes: [{ path: PublishingAPISection.base_path(@manual_slug, @section_slug), type: :exact }],
         locale: "en",
       )

--- a/config/initializers/frontend_base_url.rb
+++ b/config/initializers/frontend_base_url.rb
@@ -1,5 +1,5 @@
 FRONTEND_BASE_URL = if Rails.env.development?
-                      Plek.new.find("manuals-frontend")
+                      Plek.new.find("government-frontend")
                     else
                       Plek.current.website_root
                     end

--- a/public/json_examples/send_to_publishing_api/manual.json
+++ b/public/json_examples/send_to_publishing_api/manual.json
@@ -42,7 +42,7 @@
     ]
   },
   "publishing_app": "hmrc-manuals-api",
-  "rendering_app": "manuals-frontend",
+  "rendering_app": "government-frontend",
   "routes": [
     {
       "path": "/hmrc-internal-manuals/employment-income-manual",

--- a/public/json_examples/send_to_publishing_api/section.json
+++ b/public/json_examples/send_to_publishing_api/section.json
@@ -38,7 +38,7 @@
     ]
   },
   "publishing_app": "hmrc-manuals-api",
-  "rendering_app": "manuals-frontend",
+  "rendering_app": "government-frontend",
   "routes": [
     {
       "path": "/hmrc-manuals/employment-income-manual/eim00100",

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -41,7 +41,7 @@ module PublishingApiDataHelpers
         ],
       },
       "publishing_app" => "hmrc-manuals-api",
-      "rendering_app" => "manuals-frontend",
+      "rendering_app" => "government-frontend",
       "routes" => [
         {
           "path" => "/hmrc-internal-manuals/employment-income-manual",
@@ -96,7 +96,7 @@ module PublishingApiDataHelpers
         ],
       },
       "publishing_app" => "hmrc-manuals-api",
-      "rendering_app" => "manuals-frontend",
+      "rendering_app" => "government-frontend",
       "routes" => [
         {
           "path" => "/hmrc-internal-manuals/employment-income-manual/12345",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## WHAT
Update rendering app to government-frontend

## WHY
We'd like to migrate the rendering so we can retire manuals-frontend as on trello ticket.

### Trello
https://trello.com/c/e8XNP4Sk/1128-manuals-change-manuals-publisher-and-hmrc-manuals-api-rendering-app

## RELATED
https://github.com/alphagov/manuals-publisher/pull/1844
https://github.com/alphagov/govuk-developer-docs/pull/3460
