### PR TITLE
Fix missing asset_home error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,12 +25,12 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
We are currently getting this error in the app:
```
NoMethodError: undefined method `assets' for #<Rails::Application::Configuration:0x000056021751d640>
Did you mean?  asset_host
  /app/vendor/bundle/ruby/2.7.0/gems/railties-7.0.2.3/lib/rails/railtie/configuration.rb:96:in `method_missing'
  /app/config/environments/production.rb:28:in `block in <top (required)>'
  /app/vendor/bundle/ruby/2.7.0/gems/railties-7.0.2.3/lib/rails/railtie.rb:251:in `instance_eval'
  /app/vendor/bundle/ruby/2.7.0/gems/railties-7.0.2.3/lib/rails/railtie.rb:251:in `configure'
  /app/config/environments/production.rb:3:in `<top (required)>'
```

This commit fixes that.

Ref:
1. [pr removing asset initializer](#670)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
