### PR TITLE
Set phase to 'beta' for HMRC manuals

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -34,6 +34,7 @@ class PublishingAPIManual
           { path: updates_path, type: :exact },
         ],
         locale: "en",
+        phase: "beta",
       )
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -32,6 +32,7 @@ class PublishingAPISection
         rendering_app: "manuals-frontend",
         routes: [{ path: PublishingAPISection.base_path(@manual_slug, @section_slug), type: :exact }],
         locale: "en",
+        phase: "beta",
       )
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -3,6 +3,7 @@ module PublishingApiDataHelpers
     {
       "base_path" => "/hmrc-internal-manuals/employment-income-manual",
       "locale" => "en",
+      "phase" => "beta",
       "update_type" => "major",
       "document_type" => "hmrc_manual",
       "schema_name" => "hmrc_manual",
@@ -66,6 +67,7 @@ module PublishingApiDataHelpers
       "update_type" => "minor",
       "schema_name" => "hmrc_manual_section",
       "locale" => "en",
+      "phase" => "beta",
       "title" => "A section on a part of employment income",
       "description" => "Some description",
       "public_updated_at" => "2014-01-23T00:00:00+01:00",


### PR DESCRIPTION
Currently HMRC manuals / sections have a 'beta' banner when they're
rendered by Manuals Frontend. This is done via some custom logic
depending on whether the manual is from HMRC. However, the correct way
to indicate a content item's phase is to set the 'phase' attribute on
the content item instead.

We need to do this as we migrate from Manuals Frontend to Government
Frontend.

Tested on integration by publishing a new manual and it successfully sets the phase attribute.

### Test request 

```
curl -i -XPUT -H'Authorization: Bearer <inserted-token>' -H'Accept: application/json'   -H'Content-Type: application/json' --data-binary '{"title":"hello", "description":"desc", "public_updated_at":"2014-01-23T00:00:00+01:00", "details": { "child_section_groups": []}, "update_type":"major"}' localhost:3071/hmrc-manuals/peters-test
```

Trello:
https://trello.com/c/sCpFwYz6/1213-migrate-hmrc-manuals-from-live-to-beta

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
