### PR TITLE
Fix tests, console in dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Suppress logger output for asset requests.
-  config.assets.quiet = true
+  # config.assets.quiet = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
No assets, so remove that reference which prevents us
from getting into a console in dev mode or running
the linter as part of the default rake task

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
