### PR TITLE
Revert "Add parent manuals title to section"

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -87,14 +87,6 @@ class PublishingAPIManual
     "#{base_path(manual_slug)}/updates"
   end
 
-  def self.title(manual_slug)
-    content_id = GdsApi.publishing_api.lookup_content_id(base_path: base_path(manual_slug))
-    return nil unless content_id
-
-    content_item = GdsApi.publishing_api.get_live_content(content_id)
-    content_item["title"]
-  end
-
   def save!
     raise ValidationError, "manual is invalid" unless valid?
 

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -7,7 +7,6 @@ class PublishingAPISection
   include Helpers::PublishingAPIHelpers
 
   validates :to_h, no_dangerous_html_in_text_fields: true, if: -> { @section.valid? }
-  validates :to_h, parent_manual_title: true, if: -> { @section.valid? }
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates :manual_slug, slug_in_known_manual_slugs: true, if: :only_known_hmrc_manual_slugs?
   validate :incoming_section_is_valid
@@ -38,7 +37,7 @@ class PublishingAPISection
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_breadcrumbs(enriched_data)
-      add_base_path_and_title_to_manual(enriched_data)
+      add_base_path_to_manual(enriched_data)
     end
   end
 
@@ -109,12 +108,10 @@ private
     attributes
   end
 
-  def add_base_path_and_title_to_manual(attributes)
+  def add_base_path_to_manual(attributes)
     attributes["details"]["manual"] = {
       "base_path" => PublishingAPIManual.base_path(@manual_slug),
-      "title" => PublishingAPIManual.title(@manual_slug),
     }
-
     attributes
   end
 

--- a/app/validators/parent_manual_title_validator.rb
+++ b/app/validators/parent_manual_title_validator.rb
@@ -1,5 +1,0 @@
-class ParentManualTitleValidator < ActiveModel::Validator
-  def validate(record)
-    record.errors.add :manual_title, "Unable to find parent manual's title as manual doesn't exist in Publishing API for base_path: #{record.to_h.dig('details', 'manual', 'base_path')}" unless record.to_h.dig("details", "manual", "title")
-  end
-end

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -1,14 +1,6 @@
 require "rails_helper"
-require "gds_api/test_helpers/publishing_api"
 
 describe PublishingAPISection do
-  include GdsApi::TestHelpers::PublishingApi
-
-  before do
-    stub_publishing_api_has_lookups({ "/hmrc-internal-manuals/some-slug" => maximal_manual_content_id })
-    stub_publishing_api_has_item(maximal_manual_for_publishing_api(content_id: maximal_manual_content_id, publication_state: "published"))
-  end
-
   describe ".base_path" do
     it "returns the GOV.UK path for the section" do
       base_path = PublishingAPISection.base_path("some-manual", "some-section-id")
@@ -137,13 +129,6 @@ describe PublishingAPISection do
       it { should_not be_valid }
     end
 
-    context "with a missing parent manual" do
-      let(:attributes) { valid_section }
-      let(:section_slug) { valid_section["details"]["section_id"] }
-      before { stub_publishing_api_has_lookups({}) }
-      it { should_not be_valid }
-    end
-
     context "when app is configured to only allow known manual slugs" do
       let(:attributes) { valid_section }
       # section_slug and section_id have to match to pass `:section_slug_matches_section_id` validation
@@ -160,11 +145,6 @@ describe PublishingAPISection do
 
       context "with a manual slug name in list of known slugs" do
         let(:manual_slug) { KNOWN_MANUAL_SLUGS.first }
-
-        before do
-          stub_publishing_api_has_lookups({ "/hmrc-internal-manuals/#{manual_slug}" => maximal_manual_content_id })
-        end
-
         it { should be_valid }
       end
     end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -9,11 +9,6 @@ describe "manual sections resource" do
     "/hmrc-manuals/#{maximal_manual_slug}/sections/#{maximal_section_slug}"
   end
 
-  before do
-    stub_publishing_api_has_lookups({ maximal_manual_base_path => maximal_manual_content_id })
-    stub_publishing_api_has_item(maximal_manual_for_publishing_api(content_id: maximal_manual_content_id, publication_state: "published"))
-  end
-
   it "confirms update of the manual section" do
     stub_publishing_api_put_content(maximal_section_content_id, {}, body: { version: 788 })
     stub_publishing_api_publish(maximal_section_content_id, { update_type: nil, previous_version: 788 }.to_json)
@@ -41,18 +36,6 @@ describe "manual sections resource" do
                    "HTTP_ACCEPT" => "text/plain",
                    "HTTP_AUTHORIZATION" => "Bearer 12345" }
     expect(response.status).to eq(406)
-  end
-
-  it "errors if the parent manual does not exist (so can't copy title)" do
-    stub_publishing_api_has_lookups({})
-
-    put maximal_section_endpoint,
-        params: maximal_section.to_json,
-        headers: { "CONTENT_TYPE" => "application/json",
-                   "HTTP_ACCEPT" => "text/plain",
-                   "HTTP_AUTHORIZATION" => "Bearer 12345" }
-    expect(response.status).to eq(422)
-    expect(json_response["errors"]).to include("Manual title Unable to find parent manual's title as manual doesn't exist in Publishing API for base_path: /hmrc-internal-manuals/employment-income-manual")
   end
 
   it "errors if the Content-Type header is not application/json" do
@@ -105,14 +88,14 @@ describe "manual sections resource" do
     put_json "/hmrc-manuals/BREAK_THE_RULEZ/sections/some-section", valid_section
 
     expect(response.status).to eq(422)
-    expect(json_response["errors"]).to include("Manual slug should match the pattern: (?-mix:\\A[a-z\\d]+(?:-[a-z\\d]+)*\\z)")
+    expect(json_response["errors"].first).to eq("Manual slug should match the pattern: (?-mix:\\A[a-z\\d]+(?:-[a-z\\d]+)*\\z)")
   end
 
   it "rejects invalid section slugs" do
     put_json "/hmrc-manuals/some-manual/sections/BREAK_THE_RULEZ", valid_section
 
     expect(response.status).to eq(422)
-    expect(json_response["errors"]).to include("Section slug should match the pattern: (?-mix:\\A[a-z\\d]+(?:-[a-z\\d]+)*\\z)")
+    expect(json_response["errors"].first).to eq("Section slug should match the pattern: (?-mix:\\A[a-z\\d]+(?:-[a-z\\d]+)*\\z)")
   end
 
 private

--- a/spec/requests/sanitisation_spec.rb
+++ b/spec/requests/sanitisation_spec.rb
@@ -1,9 +1,6 @@
 require "rails_helper"
-require "gds_api/test_helpers/publishing_api"
 
 describe "Dangerous markup" do
-  include GdsApi::TestHelpers::PublishingApi
-
   context "in manuals" do
     context "(disallowed HTML tags)" do
       let(:manual_with_script_tag_in_title) { valid_manual(title: "<script>text</script>") }
@@ -31,11 +28,6 @@ describe "Dangerous markup" do
   end
 
   context "in sections" do
-    before do
-      stub_publishing_api_has_lookups({ maximal_manual_base_path => maximal_manual_content_id })
-      stub_publishing_api_has_item(maximal_manual_for_publishing_api(content_id: maximal_manual_content_id, publication_state: "published"))
-    end
-
     context "(disallowed HTML tags)" do
       let(:section_with_disallowed_html_tag_in_title) { valid_section(title: "<script>text</script>") }
 

--- a/spec/requests/validation_spec.rb
+++ b/spec/requests/validation_spec.rb
@@ -68,17 +68,12 @@ describe "validation" do
   end
 
   context "for manual sections" do
-    before do
-      stub_publishing_api_has_lookups({ "/hmrc-internal-manuals/imaginary-slug" => maximal_manual_content_id })
-      stub_publishing_api_has_item(maximal_manual_for_publishing_api(content_id: maximal_manual_content_id, publication_state: "published"))
-    end
-
     it "validates for the presence of the title" do
       put_json "/hmrc-manuals/imaginary-slug/sections/imaginary-section", section_without_title
 
       expect(response.status).to eq(422)
       expect(json_response).to include("status" => "error")
-      expect(json_response["errors"]).to include(%r{The property '#/' did not contain a required property of 'title' in schema})
+      expect(json_response["errors"].first).to match(%r{The property '#/' did not contain a required property of 'title' in schema})
     end
 
     it "validates for known manual slug name in production environment" do
@@ -88,7 +83,7 @@ describe "validation" do
 
       expect(response.status).to eq(422)
       expect(json_response).to include("status" => "error")
-      expect(json_response["errors"]).to include("Manual slug does not match any of the following valid slugs: #{KNOWN_MANUAL_SLUGS.join(' ')} ")
+      expect(json_response["errors"].first).to match("does not match any of the following valid slugs: #{KNOWN_MANUAL_SLUGS.join(' ')}")
     end
   end
 end

--- a/spec/support/publishing_api_data_helpers.rb
+++ b/spec/support/publishing_api_data_helpers.rb
@@ -76,7 +76,6 @@ module PublishingApiDataHelpers
         "section_id" => "12345",
         "manual" => {
           "base_path" => "/hmrc-internal-manuals/employment-income-manual",
-          "title" => "Employment Income Manual",
         },
         "breadcrumbs" => [
           {


### PR DESCRIPTION
Reverts alphagov/hmrc-manuals-api#702

We're no longer want to add the manual title to the manual section. We originally wanted to add all the attributes a section needed when it renders, but this is more complicated than first thought.

The main reason we're reverting this change is because HMRC Manuals API could error when publishing a new manual, as the new code relies on a manual being published before a section and there is no validation ensuring this happens.

Dependant on: https://github.com/alphagov/govuk-content-schemas/pull/1108

Trello:
https://trello.com/c/ItYKGMqF/1464-revert-add-parent-manuals-title-to-the-hmrc-section-content-item