### PR TITLE
Remove unnecessary `RUN mkdir /app` from Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
 
 FROM $builder_image AS builder
 
-RUN mkdir /app
-
 WORKDIR /app
 COPY Gemfile* .ruby-version /app/
 
@@ -12,13 +10,13 @@ RUN BUNDLE_WITHOUT='development test webkit' bundle install
 
 COPY . /app
 
+
 FROM $base_image
 
 ENV GOVUK_APP_NAME=hmrc-manuals-api
 
+WORKDIR /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
-
-WORKDIR /app
 
 CMD bundle exec puma


### PR DESCRIPTION
`WORKDIR` creates its directory anyway, and the mkdir was failing now that we're creating `/app` in govuk-ruby-base. Thought I'd fixed all of these before merging that change, but clearly I missed at least this one.