### PR TITLE
Update Plek.current to Plek.new

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -12,10 +12,10 @@ module Services
   end
 
   def self.search_api
-    @search_api ||= GdsApi::Search.new(Plek.current.find("search"))
+    @search_api ||= GdsApi::Search.new(Plek.new.find("search"))
   end
 
   def self.content_store
-    @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+    @content_store ||= GdsApi::ContentStore.new(Plek.new.find("content-store"))
   end
 end

--- a/config/initializers/frontend_base_url.rb
+++ b/config/initializers/frontend_base_url.rb
@@ -1,5 +1,5 @@
 FRONTEND_BASE_URL = if Rails.env.development?
                       Plek.new.find("government-frontend")
                     else
-                      Plek.current.website_root
+                      Plek.new.website_root
                     end


### PR DESCRIPTION
Usage of Plek.current was marked as deprecated in https://github.com/alphagov/plek/pull/94, therefore we should remove uses of the old syntax now we've upgraded Plek, else we'll log lots of deprecation warnings.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
