### PR TITLE
Use canonical name when connecting to search-api.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
     ffi (1.15.5)
-    gds-api-adapters (83.0.0)
+    gds-api-adapters (84.0.0)
       addressable
       link_header
       null_logger

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -12,7 +12,7 @@ module Services
   end
 
   def self.search_api
-    @search_api ||= GdsApi::Search.new(Plek.new.find("search"))
+    @search_api ||= GdsApi::Search.new(Plek.new.find("search-api"))
   end
 
   def self.content_store


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170 for context.