### PR TITLE
Replace archived govuk-content-schema-test-helpers with govuk_schemas.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 
 group :test do
   gem "ci_reporter_rspec"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "simplecov", require: false
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (~> 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (4.10.1)
       logstasher (~> 2.1)
       plek (~> 4)
@@ -142,6 +140,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.4.1)
+      json-schema (~> 2.8.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
     htmlentities (4.3.4)
@@ -403,8 +403,8 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   govspeak
-  govuk-content-schema-test-helpers
   govuk_app_config
+  govuk_schemas
   json-schema
   listen
   plek

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -56,13 +56,13 @@ describe PublishingAPIManual do
     subject { publishing_api_manual.to_h }
 
     context "valid_manual" do
-      it { should be_valid_against_schema("hmrc_manual") }
+      it { should be_valid_against_publisher_schema("hmrc_manual") }
     end
 
     context "maximal_manual" do
       let(:attributes) { maximal_manual }
 
-      it { should be_valid_against_schema("hmrc_manual") }
+      it { should be_valid_against_publisher_schema("hmrc_manual") }
     end
   end
 

--- a/spec/models/publishing_api_redirected_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_manual_spec.rb
@@ -56,7 +56,7 @@ describe PublishingAPIRedirectedManual do
     subject(:redirected_manual_as_hash) { redirected_manual.to_h }
 
     context "valid schema" do
-      it { should be_valid_against_schema("redirect") }
+      it { should be_valid_against_publisher_schema("redirect") }
     end
 
     it "is a redirect document type" do

--- a/spec/models/publishing_api_redirected_section_spec.rb
+++ b/spec/models/publishing_api_redirected_section_spec.rb
@@ -70,7 +70,7 @@ describe PublishingAPIRedirectedSection do
     subject(:redirected_manual_section_as_hash) { redirected_manual_section.to_h }
 
     context "valid schema" do
-      it { should be_valid_against_schema("redirect") }
+      it { should be_valid_against_publisher_schema("redirect") }
     end
 
     it 'is a "redirect" document type' do

--- a/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
+++ b/spec/models/publishing_api_redirected_section_to_parent_manual_spec.rb
@@ -47,7 +47,7 @@ describe PublishingAPIRedirectedSectionToParentManual do
     subject(:redirected_manual_section_as_hash) { redirected_manual_section.to_h }
 
     context "valid schema" do
-      it { should be_valid_against_schema("redirect") }
+      it { should be_valid_against_publisher_schema("redirect") }
     end
 
     it 'is a "redirect" document type' do

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -46,7 +46,7 @@ describe PublishingAPIRemovedManual do
     subject(:removed_manual_as_hash) { removed_manual.to_h }
 
     context "valid schema" do
-      it { should be_valid_against_schema("gone") }
+      it { should be_valid_against_publisher_schema("gone") }
     end
 
     it 'is a "gone" document type' do

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -71,7 +71,7 @@ describe PublishingAPIRemovedSection do
     subject(:removed_manual_section_as_hash) { removed_manual_section.to_h }
 
     context "valid schema" do
-      it { should be_valid_against_schema("gone") }
+      it { should be_valid_against_publisher_schema("gone") }
     end
 
     it 'is a "gone" document type' do

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -71,13 +71,13 @@ describe PublishingAPISection do
     context "valid_section" do
       let(:attributes) { valid_section }
 
-      it { should be_valid_against_schema("hmrc_manual_section") }
+      it { should be_valid_against_publisher_schema("hmrc_manual_section") }
     end
 
     context "maximal_section" do
       let(:attributes) { maximal_section }
 
-      it { should be_valid_against_schema("hmrc_manual_section") }
+      it { should be_valid_against_publisher_schema("hmrc_manual_section") }
     end
   end
 

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,9 +1,2 @@
-require "govuk-content-schema-test-helpers"
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end
-
-require "govuk-content-schema-test-helpers/rspec_matchers"
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
+require "govuk_schemas/rspec_matchers"
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
https://trello.com/c/b9PRFqgU/231-applications-use-govuk-content-schema-test-helpers-which-is-an-archived-gem

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
