### PR TITLE
Work around broken release of the mail rubygem + Dockerfile cleanup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ FROM $builder_image AS builder
 
 WORKDIR /app
 COPY Gemfile* .ruby-version /app/
-
-RUN BUNDLE_WITHOUT='development test webkit' bundle install
-
+# TODO: remove chmod workaround once https://www.github.com/mikel/mail/issues/1489 is fixed.
+RUN bundle install && chmod -R o+r "${BUNDLE_PATH}"
 COPY . /app
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,19 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
 FROM $builder_image AS builder
 
-WORKDIR /app
+WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version /app/
 # TODO: remove chmod workaround once https://www.github.com/mikel/mail/issues/1489 is fixed.
 RUN bundle install && chmod -R o+r "${BUNDLE_PATH}"
-COPY . /app
+COPY . ./
 
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=hmrc-manuals-api
 
-WORKDIR /app
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME ./
 
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]


### PR DESCRIPTION
This only affects running on Kubernetes. No change to existing production.

Tested: builds and runs as far as Puma startup on Docker Desktop