### PR TITLE
Add a slug for economic-crime-supervision-handbook

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -55,6 +55,7 @@ KNOWN_MANUAL_SLUGS = %w[
   ec-export-preferences
   ec-preferences-exports-turkey
   ec-preferences-imports-turkey
+  economic-crime-supervision-handbook
   employee-tax-advantaged-share-scheme-user-manual
   employment-income-manual
   employment-related-securities


### PR DESCRIPTION
A request has come in through zendesk to add a new slug.

https://govuk.zendesk.com/agent/tickets/5233904

This is added follow the docs here: https://github.com/alphagov/hmrc-manuals-api#adding-a-new-slug

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
