### PR TITLE
Add new slug plastic-packaging-tax-manual

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -125,6 +125,7 @@ KNOWN_MANUAL_SLUGS = %w[
   paye-manual
   paye-settlement-agreements
   pensions-tax-manual
+  plastic-packaging-tax-manual
   property-income-manual
   registered-pensions-scheme-manual
   relief-instructions


### PR DESCRIPTION
A request has come in through zendesk to add a new slug.

https://govuk.zendesk.com/agent/tickets/5244512

[Docs on adding a new slug](https://github.com/alphagov/hmrc-manuals-api#adding-a-new-slug), we will need to re-deploy the app to generate the new slug.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
