### PR TITLE
Add avoidance-handling-process slug to known_manual_slugs

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -11,6 +11,7 @@ KNOWN_MANUAL_SLUGS = %w[
   appeals-reviews-and-tribunals-guidance
   apprenticeship-levy
   ata-cpd-carnets
+  avoidance-handling-process
   bank-levy-manual
   banking-manual
   beer-manual


### PR DESCRIPTION
## Description

We've been contacts by HMRC to add a new slug for `avoidance-handling-process` 
https://govuk.zendesk.com/agent/tickets/5486432

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
