### PR TITLE
Add new test site for HMRC

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -148,6 +148,7 @@ KNOWN_MANUAL_SLUGS = %w[
   self-assessment-manual
   senior-accounting-officers-guidance
   shared-workspace-business-manual
+  sharepoint-tax-manuals-test-site
   shares-and-assets-valuation-manual
   ships-report
   soft-drinks-industry-levy


### PR DESCRIPTION
HMRC have asked us to add a new site so that they can test their new sharepoint based solution to tax manuals

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
