### PR TITLE
Add slug for tobacco-track-and-trace-compliance manual

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -171,6 +171,7 @@ KNOWN_MANUAL_SLUGS = %w[
   tobacco-control-of-supply-chains
   tobacco-products-duty
   tobacco-products-manufacturing-machinery-licensing-scheme
+  tobacco-track-and-trace-compliance
   tonnage-tax-manual
   trust-registration-service-manual
   trusts-settlements-and-estates-manual


### PR DESCRIPTION
Requested by: https://govuk.zendesk.com/agent/tickets/5577801

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
