### PR TITLE
Add new manual slug

### DIFF
--- a/config/initializers/known_manual_slugs.rb
+++ b/config/initializers/known_manual_slugs.rb
@@ -41,6 +41,7 @@ KNOWN_MANUAL_SLUGS = %w[
   corporate-finance-manual
   corporate-intangibles-research-and-development-manual
   cotax-manual
+  creative-industries-expenditure-credit-manual
   cryptoassets-manual
   customs-authorisation-and-approval
   customs-cds-volume-3-tariff-step-by-step-guide


### PR DESCRIPTION
Adds `creative-industries-expenditure-credit-manual` as requested in https://govuk.zendesk.com/agent/tickets/5669844.

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

[Trello card](https://trello.com/c/YPmXaxgp)