### PR TITLE
Lookup section title in change notes when none is given

### DIFF
--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -36,6 +36,7 @@ class PublishingAPIManual
       enriched_data = StructWithRenderedMarkdown.new(enriched_data).to_h
       enriched_data = add_base_path_to_child_section_groups(enriched_data)
       enriched_data = add_base_path_to_change_notes(enriched_data)
+      enriched_data = add_missing_titles_to_change_notes(enriched_data)
       enriched_data
     end
   end
@@ -108,6 +109,15 @@ private
   def add_base_path_to_change_notes(attributes)
     attributes["details"]["change_notes"] && attributes["details"]["change_notes"].each do |change_note_object|
       change_note_object["base_path"] = PublishingAPISection.base_path(@slug, change_note_object["section_id"])
+    end
+    attributes
+  end
+
+  def add_missing_titles_to_change_notes(attributes)
+    attributes["details"]["change_notes"] && attributes["details"]["change_notes"].each do |change_note_object|
+      if change_note_object["title"] == ""
+        change_note_object["title"] = PublishingAPISection.find_title(change_note_object["base_path"])
+      end
     end
     attributes
   end

--- a/app/models/publishing_api_manual.rb
+++ b/app/models/publishing_api_manual.rb
@@ -107,14 +107,14 @@ private
   end
 
   def add_base_path_to_change_notes(attributes)
-    attributes["details"]["change_notes"] && attributes["details"]["change_notes"].each do |change_note_object|
+    attributes["details"]["change_notes"]&.each do |change_note_object|
       change_note_object["base_path"] = PublishingAPISection.base_path(@slug, change_note_object["section_id"])
     end
     attributes
   end
 
   def add_missing_titles_to_change_notes(attributes)
-    attributes["details"]["change_notes"] && attributes["details"]["change_notes"].each do |change_note_object|
+    attributes["details"]["change_notes"]&.each do |change_note_object|
       if change_note_object["title"] == ""
         change_note_object["title"] = PublishingAPISection.find_title(change_note_object["base_path"])
       end

--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -64,6 +64,11 @@ class PublishingAPISection
     File.join(PublishingAPIManual.base_path(manual_slug.to_s.downcase), section_slug.to_s.downcase)
   end
 
+  def self.find_title(base_path)
+    item = Services.content_store.content_item(base_path)
+    item.to_h["title"]
+  end
+
   def self.extract_slugs_from_path(path)
     slugs = {}
     slugs[:manual] = PublishingAPIManual.extract_slug_from_path(path)

--- a/spec/models/publishing_api_manual_spec.rb
+++ b/spec/models/publishing_api_manual_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
+require "gds_api/test_helpers/content_store"
 
 describe PublishingAPIManual do
+  include GdsApi::TestHelpers::ContentStore
+
   describe ".base_path" do
     it "returns the GOV.UK path for the manual" do
       base_path = PublishingAPIManual.base_path("some-manual")
@@ -63,6 +66,22 @@ describe PublishingAPIManual do
       let(:attributes) { maximal_manual }
 
       it { should be_valid_against_publisher_schema("hmrc_manual") }
+    end
+
+    context "valid_manual_without_change_note_titles" do
+      let(:attributes) { manual_without_change_note_titles }
+      let(:path_1) { "/hmrc-internal-manuals/some-slug/abc567" }
+      let(:path_2) { "/hmrc-internal-manuals/some-slug/abc555" }
+
+      before do
+        stub_content_store_has_item(path_1, content_item_for_base_path(path_1))
+        stub_content_store_has_item(path_2, content_item_for_base_path(path_2))
+      end
+
+      it "adds the section title to the title field of the change note" do
+        expect(subject.dig("details", "change_notes").first["title"]).to eq("Hmrc internal manuals some slug abc567")
+        expect(subject.dig("details", "change_notes").second["title"]).to eq("Hmrc internal manuals some slug abc555")
+      end
     end
   end
 

--- a/spec/support/test_data_helpers.rb
+++ b/spec/support/test_data_helpers.rb
@@ -80,6 +80,32 @@ module TestDataHelpers
     }.merge(options).deep_stringify_keys
   end
 
+  def manual_without_change_note_titles(options = {})
+    {
+      title: "Employment Income Manual",
+      description: "A manual about incoming employment",
+      public_updated_at: "2014-01-23T00:00:00+01:00",
+      update_type: "minor",
+      details: {
+        child_section_groups: [],
+        change_notes: [
+          {
+            title: "",
+            section_id: "ABC567",
+            change_note: "Description of changes",
+            published_at: "2014-01-23T00:00:00+01:00",
+          },
+          {
+            title: "",
+            section_id: "ABC555",
+            change_note: "Description of changes",
+            published_at: "2013-12-23T00:00:00+01:00",
+          },
+        ],
+      },
+    }.merge(options).deep_stringify_keys
+  end
+
   def valid_section(options = {})
     {
       title: "A section on a part of employment income",


### PR DESCRIPTION
There's been an issue whereby users can leave section titles blank in change notes. This means that there's no links to the places where changes were made. This adds the title in so that it can be linked to

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

This code will run every time a manual is republished, but only looks up titles where one is missing. This should mitigate the obvious performance hit, and should mean that older manuals will have titles added when they're updated, that or we could just republish them all

Trello - https://trello.com/c/cvIp4SjN/1059-fix-hmrc-manuals-api-updates

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
