### PR TITLE
Allow previously redirected manuals to be removed

### DIFF
--- a/app/models/publishing_api_redirected_manual.rb
+++ b/app/models/publishing_api_redirected_manual.rb
@@ -6,7 +6,7 @@ class PublishingAPIRedirectedManual
 
   validates :manual_slug, :destination_manual_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
-                 schema_name: MANUAL_SCHEMA_NAME,
+                 schema_names: [MANUAL_SCHEMA_NAME],
                  content_store: Services.content_store,
                  unless: lambda {
                    errors[:manual_slug].present? || errors[:destination_manual_slug].present?

--- a/app/models/publishing_api_redirected_section.rb
+++ b/app/models/publishing_api_redirected_section.rb
@@ -7,7 +7,7 @@ class PublishingAPIRedirectedSection
   validates :manual_slug, :section_slug, :destination_manual_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates :destination_section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }, allow_nil: true
   validates_with InContentStoreValidator,
-                 schema_name: SECTION_SCHEMA_NAME,
+                 schema_names: [SECTION_SCHEMA_NAME],
                  content_store: Services.content_store,
                  unless: lambda {
                    errors[:manual_slug].present? ||

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -6,7 +6,7 @@ class PublishingAPIRemovedManual
 
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
-                 schema_names: [MANUAL_SCHEMA_NAME],
+                 schema_names: [MANUAL_SCHEMA_NAME, "redirect"],
                  content_store: Services.content_store,
                  unless: -> { errors[:slug].present? }
 

--- a/app/models/publishing_api_removed_manual.rb
+++ b/app/models/publishing_api_removed_manual.rb
@@ -6,7 +6,7 @@ class PublishingAPIRemovedManual
 
   validates :slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
-                 schema_name: MANUAL_SCHEMA_NAME,
+                 schema_names: [MANUAL_SCHEMA_NAME],
                  content_store: Services.content_store,
                  unless: -> { errors[:slug].present? }
 

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -6,7 +6,7 @@ class PublishingAPIRemovedSection
 
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
-                 schema_names: [SECTION_SCHEMA_NAME],
+                 schema_names: [SECTION_SCHEMA_NAME, "redirect"],
                  content_store: Services.content_store,
                  unless: -> { errors[:manual_slug].present? || errors[:section_slug].present? }
 

--- a/app/models/publishing_api_removed_section.rb
+++ b/app/models/publishing_api_removed_section.rb
@@ -6,7 +6,7 @@ class PublishingAPIRemovedSection
 
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validates_with InContentStoreValidator,
-                 schema_name: SECTION_SCHEMA_NAME,
+                 schema_names: [SECTION_SCHEMA_NAME],
                  content_store: Services.content_store,
                  unless: -> { errors[:manual_slug].present? || errors[:section_slug].present? }
 

--- a/app/validators/in_content_store_validator.rb
+++ b/app/validators/in_content_store_validator.rb
@@ -36,6 +36,6 @@ private
   end
 
   def wrong_schema_name_message(_record, content_item)
-    %{Exists in the content store, but is not a "#{schema_name}" schema (it's a "#{content_item['schema_name']}" schema)"}
+    %{Exists in the content store, but is not a "#{schema_name}" schema (it's a "#{content_item['schema_name']}" schema)}
   end
 end

--- a/spec/models/publishing_api_removed_manual_spec.rb
+++ b/spec/models/publishing_api_removed_manual_spec.rb
@@ -34,6 +34,12 @@ describe PublishingAPIRemovedManual do
         expect(subject).to be_valid
       end
 
+      it 'is valid when the slugs represent a "redirect" piece of content' do
+        content_item = hmrc_manual_content_item_for_base_path(manual_path).merge("schema_name" => "redirect")
+        stub_content_store_has_item(manual_path, content_item)
+        expect(subject).to be_valid
+      end
+
       it "is invalid when the slug represents a piece of content with any other schema_name" do
         stub_content_store_has_item(manual_path)
         expect(subject).not_to be_valid

--- a/spec/models/publishing_api_removed_section_spec.rb
+++ b/spec/models/publishing_api_removed_section_spec.rb
@@ -59,6 +59,12 @@ describe PublishingAPIRemovedSection do
         expect(subject).to be_valid
       end
 
+      it 'is valid when the slugs represent a "redirect" piece of content' do
+        content_item = hmrc_manual_section_content_item_for_base_path(section_path).merge("schema_name" => "redirect")
+        stub_content_store_has_item(section_path, content_item)
+        expect(subject).to be_valid
+      end
+
       it "is invalid when the slugs represents a piece of content with any other schema_name" do
         stub_content_store_has_item(section_path)
         expect(subject).not_to be_valid

--- a/spec/validators/in_content_store_validator_spec.rb
+++ b/spec/validators/in_content_store_validator_spec.rb
@@ -7,11 +7,11 @@ describe InContentStoreValidator do
   subject do
     InContentStoreValidator.new(
       content_store:,
-      schema_name:,
+      schema_names:,
     )
   end
   let(:content_store) { Services.content_store }
-  let(:schema_name) { MANUAL_SCHEMA_NAME }
+  let(:schema_names) { [MANUAL_SCHEMA_NAME, "redirect"] }
 
   let(:manual) { PublishingAPIManual.new(slug, attributes) }
   let(:slug) { "some-slug" }
@@ -33,7 +33,7 @@ describe InContentStoreValidator do
     let(:content_item_schema_name) { "invalid-schema-name" }
     it "returns an error" do
       expect(subject.validate(manual).attribute).to eq(:base)
-      expect(subject.validate(manual).type).to eq("Exists in the content store, but is not a \"#{MANUAL_SCHEMA_NAME}\" schema (it's a \"invalid-schema-name\" schema)")
+      expect(subject.validate(manual).type).to eq("Exists in the content store, but is not a \"#{MANUAL_SCHEMA_NAME},redirect\" schema (it's a \"invalid-schema-name\" schema)")
     end
   end
 
@@ -60,10 +60,10 @@ describe InContentStoreValidator do
   end
 
   context "without a value for schema_name" do
-    let(:schema_name) { nil }
+    let(:schema_names) { nil }
 
     it "raises an error" do
-      expect { subject }.to raise_error(RuntimeError, "Must provide schema_name and content_store options to the validator")
+      expect { subject }.to raise_error(RuntimeError, "Must provide schema_names and content_store options to the validator")
     end
   end
 
@@ -71,15 +71,15 @@ describe InContentStoreValidator do
     let(:content_store) { nil }
 
     it "raises an error" do
-      expect { subject }.to raise_error(RuntimeError, "Must provide schema_name and content_store options to the validator")
+      expect { subject }.to raise_error(RuntimeError, "Must provide schema_names and content_store options to the validator")
     end
   end
 
-  context "with 'gone' as the schema_name" do
-    let(:schema_name) { "gone" }
+  context "with 'gone' as one of the schema_names" do
+    let(:schema_names) { %w[gone] }
 
     it "raises an error" do
-      expect { subject }.to raise_error(RuntimeError, "Can't provide \"gone\" as a schema_name to the validator")
+      expect { subject }.to raise_error(RuntimeError, "Can't provide \"gone\" as schema_names to the validator")
     end
   end
 end

--- a/spec/validators/in_content_store_validator_spec.rb
+++ b/spec/validators/in_content_store_validator_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+require "gds_api/test_helpers/content_store"
+
+describe InContentStoreValidator do
+  include GdsApi::TestHelpers::ContentStore
+
+  subject do
+    InContentStoreValidator.new(
+      content_store:,
+      schema_name:,
+    )
+  end
+  let(:content_store) { Services.content_store }
+  let(:schema_name) { MANUAL_SCHEMA_NAME }
+
+  let(:manual) { PublishingAPIManual.new(slug, attributes) }
+  let(:slug) { "some-slug" }
+  let(:attributes) { valid_manual }
+  let(:content_item_schema_name) { MANUAL_SCHEMA_NAME }
+
+  before do
+    stub_content_store_has_item("/hmrc-internal-manuals/#{slug}",
+                                content_item_for_base_path("/hmrc-internal-manuals/#{slug}").merge(schema_name: content_item_schema_name))
+  end
+
+  context "with a matching schema name" do
+    it "returns no errors" do
+      expect(subject.validate(manual)).to be_nil
+    end
+  end
+
+  context "with an invalid schema name" do
+    let(:content_item_schema_name) { "invalid-schema-name" }
+    it "returns an error" do
+      expect(subject.validate(manual).attribute).to eq(:base)
+      expect(subject.validate(manual).type).to eq("Exists in the content store, but is not a \"#{MANUAL_SCHEMA_NAME}\" schema (it's a \"invalid-schema-name\" schema)")
+    end
+  end
+
+  context "with a content item that does not exist" do
+    before do
+      stub_content_store_does_not_have_item("/hmrc-internal-manuals/#{slug}")
+    end
+
+    it "returns an error" do
+      expect(subject.validate(manual).attribute).to eq(:base)
+      expect(subject.validate(manual).type).to eq("Is not a manual in the content store")
+    end
+  end
+
+  context "with a content item that is gone" do
+    before do
+      stub_content_store_has_gone_item("/hmrc-internal-manuals/#{slug}")
+    end
+
+    it "returns an error" do
+      expect(subject.validate(manual).attribute).to eq(:base)
+      expect(subject.validate(manual).type).to eq("Exists in the content store, but is already \"gone\"")
+    end
+  end
+
+  context "without a value for schema_name" do
+    let(:schema_name) { nil }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(RuntimeError, "Must provide schema_name and content_store options to the validator")
+    end
+  end
+
+  context "without a value for content_store" do
+    let(:content_store) { nil }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(RuntimeError, "Must provide schema_name and content_store options to the validator")
+    end
+  end
+
+  context "with 'gone' as the schema_name" do
+    let(:schema_name) { "gone" }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(RuntimeError, "Can't provide \"gone\" as a schema_name to the validator")
+    end
+  end
+end


### PR DESCRIPTION
If a manual or a section has been previously redirected, it has a schema of `redirect`. This means we cannot subsequently remove the manual or the redirect, as the new content item won't be valid.

Therefore allowing a schema of `redirect` for us to be able to remove a manual or a section that has previously been redirected.

[Trello card](https://trello.com/c/Shh2iPTU)