### PR TITLE
Return 422 when request is unprocessable by Publishing API

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -14,6 +14,8 @@ class ManualsController < ApplicationController
       end
     rescue ActionController::UnknownFormat
       render json: { status: "error", errors: "Invalid Accept header" }, status: :not_acceptable
+    rescue GdsApi::HTTPUnprocessableEntity => e
+      render json: { status: "error", errors: e }, status: :unprocessable_entity
     rescue ValidationError
       render json: { status: "error", errors: manual.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -15,6 +15,8 @@ class SectionsController < ApplicationController
       end
     rescue ActionController::UnknownFormat
       render json: { status: "error", errors: "Invalid Accept header" }, status: :not_acceptable
+    rescue GdsApi::HTTPUnprocessableEntity => e
+      render json: { status: "error", errors: e }, status: :unprocessable_entity
     rescue ValidationError
       render json: { status: "error", errors: section.errors.full_messages }, status: :unprocessable_entity
     end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -4,6 +4,7 @@ require "gds_api/test_helpers/publishing_api"
 describe "manual sections resource" do
   include GdsApi::TestHelpers::PublishingApi
   include LinksUpdateHelper
+  include PublishingApiHelper
 
   let(:maximal_section_endpoint) do
     "/hmrc-manuals/#{maximal_manual_slug}/sections/#{maximal_section_slug}"
@@ -65,12 +66,12 @@ describe "manual sections resource" do
     expect(response.status).to eq(503)
   end
 
-  it "handles some other error with the Publishing API" do
+  it "handles the Publishing API returning an unproccessable entity error" do
     publishing_api_validation_error
 
     put_json maximal_section_endpoint, maximal_section
 
-    expect(response.status).to eq(500)
+    expect(response.status).to eq(422)
   end
 
   it "returns the status code from the Publishing API response" do
@@ -102,9 +103,5 @@ private
 
   def publishing_api_times_out
     stub_request(:any, /#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}\/.*/).to_timeout
-  end
-
-  def publishing_api_validation_error
-    stub_request(:any, /#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status: 422)
   end
 end

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -4,6 +4,7 @@ require "gds_api/test_helpers/publishing_api"
 describe "manuals resource" do
   include GdsApi::TestHelpers::PublishingApi
   include LinksUpdateHelper
+  include PublishingApiHelper
 
   it "confirms update of the manual" do
     stub_any_publishing_api_call
@@ -35,6 +36,14 @@ describe "manuals resource" do
     put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
     expect(response.status).to eq(500)
+  end
+
+  it "handles the Publishing API returning an unproccessable entity error" do
+    publishing_api_validation_error
+
+    put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
+
+    expect(response.status).to eq(422)
   end
 
   it "returns the status code from the Publishing API response" do

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,0 +1,5 @@
+module PublishingApiHelper
+  def publishing_api_validation_error
+    stub_request(:any, /#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status: 422)
+  end
+end


### PR DESCRIPTION
If the user provides data that is unprocessable by Publishing API (e.g. a base path with the incorrect content ID), we currently return a 500 error and log this to Sentry.

This is not optimal behaviour as there is no application fault here, so no action can be taken by developers after seeing this logged in Sentry.

Instead we should respond with a 422 and return the actual error to the user. Then they can correct the request they are making so it becomes valid.

[Trello card](https://trello.com/c/oAIfiY5s)