### PR TITLE
[PP-7620] Do not allow section breadcrumbs to self reference

### DIFF
--- a/app/models/publishing_api_section.rb
+++ b/app/models/publishing_api_section.rb
@@ -8,6 +8,7 @@ class PublishingAPISection
   validates :manual_slug, :section_slug, format: { with: ValidSlug::PATTERN, message: "should match the pattern: #{ValidSlug::PATTERN}" }
   validate :incoming_section_is_valid
   validate :section_slug_matches_section_id, if: -> { @section.valid? }
+  validate :breadcrumbs_do_not_self_reference, if: -> { @section.valid? }
 
   attr_accessor :manual_slug, :section_slug, :section_attributes
 
@@ -126,6 +127,17 @@ private
   def section_slug_matches_section_id
     unless section_slug.to_s.casecmp(section_attributes["details"]["section_id"].downcase).zero?
       errors.add(:base, "Slug in URL and Section ID must match, ignoring case")
+    end
+  end
+
+  def breadcrumbs_do_not_self_reference
+    details = section_attributes["details"]
+    return unless details["breadcrumbs"]
+
+    if details["breadcrumbs"].any? do |breadcrumb|
+      breadcrumb["section_id"] == details["section_id"]
+    end
+      errors.add(:base, "Breadcrumbs must not include the section they are added to")
     end
   end
 end

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -63,7 +63,7 @@ describe PublishingAPISection do
     PublishingAPISection.new(manual_slug, section_slug, attributes)
   end
   let(:manual_slug) { "some-slug" }
-  let(:section_slug) { "some_id" }
+  let(:section_slug) { "12345" }
 
   describe "#to_h" do
     let(:subject) { publishing_api_section.to_h }

--- a/spec/models/publishing_api_section_spec.rb
+++ b/spec/models/publishing_api_section_spec.rb
@@ -128,5 +128,36 @@ describe PublishingAPISection do
       let(:attributes) { [] }
       it { should_not be_valid }
     end
+
+    context "without a breadcrumb that references itself" do
+      let(:attributes) { valid_section }
+
+      before do
+        attributes["details"]["breadcrumbs"] = [
+          {
+            "section_id" => "67890",
+          },
+        ]
+      end
+
+      it { should be_valid }
+    end
+
+    context "with a breadcrumb that references itself" do
+      let(:attributes) { valid_section }
+
+      before do
+        attributes["details"]["breadcrumbs"] = [
+          {
+            "section_id" => "12345",
+          },
+          {
+            "section_id" => "67890",
+          },
+        ]
+      end
+
+      it { should_not be_valid }
+    end
   end
 end

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -99,6 +99,23 @@ describe "manual sections resource" do
     expect(json_response["errors"].first).to eq("Section slug should match the pattern: (?-mix:\\A[a-z\\d]+(?:-[a-z\\d]+)*\\z)")
   end
 
+  it "rejects self referencing breadcrumbs" do
+    payload = maximal_section
+    payload["details"]["breadcrumbs"] = [
+      {
+        "section_id" => "12345",
+      },
+      {
+        "section_id" => "67890",
+      },
+    ]
+
+    put_json maximal_section_endpoint, payload
+
+    expect(response.status).to eq(422)
+    expect(json_response["errors"].first).to eq("Breadcrumbs must not include the section they are added to")
+  end
+
 private
 
   def publishing_api_times_out


### PR DESCRIPTION
There have been cases where a section includes itself as a breadcrumb.

This is incorrect, as that breadcrumb should not be present.

Adding a validation to prevent this happening again in the future.

Only an error message, not code, has been added as this is consistent with the other validation errors. We may consider adding error codes in future work.