### PR TITLE
[PP-7792] Return 409 when Publishing API returns a conflict error

### DIFF
--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -14,6 +14,8 @@ class ManualsController < ApplicationController
       end
     rescue ActionController::UnknownFormat
       render json: { status: "error", errors: "Invalid Accept header" }, status: :not_acceptable
+    rescue GdsApi::HTTPConflict => e
+      render json: { status: "error", errors: e }, status: :conflict
     rescue GdsApi::HTTPUnprocessableEntity => e
       render json: { status: "error", errors: e }, status: :unprocessable_entity
     rescue ValidationError

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -15,6 +15,8 @@ class SectionsController < ApplicationController
       end
     rescue ActionController::UnknownFormat
       render json: { status: "error", errors: "Invalid Accept header" }, status: :not_acceptable
+    rescue GdsApi::HTTPConflict => e
+      render json: { status: "error", errors: e }, status: :conflict
     rescue GdsApi::HTTPUnprocessableEntity => e
       render json: { status: "error", errors: e }, status: :unprocessable_entity
     rescue ValidationError

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -66,6 +66,14 @@ describe "manual sections resource" do
     expect(response.status).to eq(503)
   end
 
+  it "handles the Publishing API returning a conflict error" do
+    stub_publishing_api_returns_error(409)
+
+    put_json maximal_section_endpoint, maximal_section
+
+    expect(response.status).to eq(409)
+  end
+
   it "handles the Publishing API returning an unproccessable entity error" do
     stub_publishing_api_returns_error(422)
 

--- a/spec/requests/manual_sections_spec.rb
+++ b/spec/requests/manual_sections_spec.rb
@@ -67,7 +67,7 @@ describe "manual sections resource" do
   end
 
   it "handles the Publishing API returning an unproccessable entity error" do
-    publishing_api_validation_error
+    stub_publishing_api_returns_error(422)
 
     put_json maximal_section_endpoint, maximal_section
 

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -30,12 +30,12 @@ describe "manuals resource" do
     expect(response.status).to eq(503)
   end
 
-  it "handles Publishing API put_content returning 409" do
-    stub_publishing_api_put_content(maximal_manual_content_id, {}, status: 409)
+  it "handles the Publishing API returning a conflict error" do
+    stub_publishing_api_returns_error(409)
 
     put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 
-    expect(response.status).to eq(500)
+    expect(response.status).to eq(409)
   end
 
   it "handles the Publishing API returning an unproccessable entity error" do

--- a/spec/requests/manuals_spec.rb
+++ b/spec/requests/manuals_spec.rb
@@ -39,7 +39,7 @@ describe "manuals resource" do
   end
 
   it "handles the Publishing API returning an unproccessable entity error" do
-    publishing_api_validation_error
+    stub_publishing_api_returns_error(422)
 
     put_json "/hmrc-manuals/#{maximal_manual_slug}", maximal_manual
 

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,5 +1,5 @@
 module PublishingApiHelper
-  def publishing_api_validation_error
-    stub_request(:any, /#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status: 422)
+  def stub_publishing_api_returns_error(status)
+    stub_request(:any, /#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}\/.*/).to_return(status:)
   end
 end


### PR DESCRIPTION
If the user provides data that results in a conflict in Publishing API (e.g. they try to publish an already published edition), we currently return a 500 erorr and log this to Sentry.

This is not optimal behaviour as there is no application fault here, so no action can be taken by developers after seeing this logged in Sentry.

Instead we should respond with a 409 and return the actual error to the user. Then they can correct the request they are making so it becomes valid.
    
This mirrors the change made for 422 responses in #1028.