### PR TITLE
[PP-7886] Add endpoint to allow upload of assets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,6 @@ class ApplicationController < ActionController::Base
   skip_forgery_protection
 
   before_action :authenticate_user!
-  before_action :check_content_type_header
 
   rescue_from GdsApi::BaseError do |exception|
     GovukError.notify(exception)
@@ -30,7 +29,7 @@ private
     render json: { status: "error", errors: [message] }, status: :bad_request
   end
 
-  def check_content_type_header
+  def check_content_type_is_json
     if request.headers["Content-Type"] != "application/json"
       render json: { status: "error", errors: "Invalid Content-Type header" }, status: :unsupported_media_type
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,10 +13,10 @@ class ApplicationController < ActionController::Base
     if (exception.is_a?(GdsApi::HTTPErrorResponse) && (500..599).cover?(exception.code)) ||
         exception.is_a?(GdsApi::TimedOutException)
       message = "Service unavailable"
-      render json: { status: "error", errors: [message] }, status: :service_unavailable
+      error :service_unavailable, [message]
     else
       message = "Server error"
-      render json: { status: "error", errors: [message] }, status: :internal_server_error
+      error :internal_server_error, [message]
     end
   end
 
@@ -26,12 +26,16 @@ private
     @parsed_request_body = JSON.parse(request.body.read)
   rescue JSON::ParserError => e
     message = "Request JSON could not be parsed: #{e.message}"
-    render json: { status: "error", errors: [message] }, status: :bad_request
+    error :bad_request, [message]
   end
 
   def check_content_type_is_json
     if request.headers["Content-Type"] != "application/json"
-      render json: { status: "error", errors: "Invalid Content-Type header" }, status: :unsupported_media_type
+      error :unsupported_media_type, "Invalid Content-Type header"
     end
+  end
+
+  def error(status, errors)
+    render json: { status: "error", errors: }, status:
   end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -3,27 +3,38 @@ class AssetsController < ApplicationController
 
   def create
     asset = {
+      draft: asset_params[:draft].nil? || asset_params[:draft] != "false",
       file: asset_params[:file].tempfile,
     }
 
+    if asset[:draft]
+      asset[:auth_bypass_ids] = [SecureRandom.uuid]
+      asset[:auth_bypass_ids_expiry] = Time.zone.now + 30.days
+    end
+
     asset_manager_response = Services.asset_manager.create_asset(asset).to_h
+
+    output = {
+      _response_info: {
+        status: "ok",
+      },
+      asset_id: get_asset_id_from_url(asset_manager_response["file_url"]),
+      content_type: asset_manager_response["content_type"],
+      deleted: asset_manager_response["deleted"],
+      draft: asset_manager_response["draft"],
+      file_url: asset_manager_response["file_url"],
+      id: asset_manager_response["id"],
+      name: asset_manager_response["name"],
+      size: asset_manager_response["size"],
+      state: asset_manager_response["state"],
+    }
+
+    output[:file_url] = "#{asset_manager_response['file_url']}?token=#{asset[:auth_bypass_ids].first}" if asset[:auth_bypass_ids]
+    output[:preview_expiry] = asset[:auth_bypass_ids_expiry].iso8601 if asset[:auth_bypass_ids_expiry]
 
     respond_to do |format|
       format.json do
-        render status: :created, json: {
-          _response_info: {
-            status: "ok",
-          },
-          asset_id: get_asset_id_from_url(asset_manager_response["file_url"]),
-          content_type: asset_manager_response["content_type"],
-          deleted: asset_manager_response["deleted"],
-          draft: asset_manager_response["draft"],
-          file_url: asset_manager_response["file_url"],
-          id: asset_manager_response["id"],
-          name: asset_manager_response["name"],
-          size: asset_manager_response["size"],
-          state: asset_manager_response["state"],
-        }
+        render status: :created, json: output
       end
     end
   rescue ActionController::UnknownFormat

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -12,33 +12,37 @@ class AssetsController < ApplicationController
       asset[:auth_bypass_ids_expiry] = Time.zone.now + 30.days
     end
 
-    asset_manager_response = Services.asset_manager.create_asset(asset).to_h
+    begin
+      asset_manager_response = Services.asset_manager.create_asset(asset).to_h
 
-    output = {
-      _response_info: {
-        status: "ok",
-      },
-      asset_id: get_asset_id_from_url(asset_manager_response["file_url"]),
-      content_type: asset_manager_response["content_type"],
-      deleted: asset_manager_response["deleted"],
-      draft: asset_manager_response["draft"],
-      file_url: asset_manager_response["file_url"],
-      id: asset_manager_response["id"],
-      name: asset_manager_response["name"],
-      size: asset_manager_response["size"],
-      state: asset_manager_response["state"],
-    }
+      output = {
+        _response_info: {
+          status: "ok",
+        },
+        asset_id: get_asset_id_from_url(asset_manager_response["file_url"]),
+        content_type: asset_manager_response["content_type"],
+        deleted: asset_manager_response["deleted"],
+        draft: asset_manager_response["draft"],
+        file_url: asset_manager_response["file_url"],
+        id: asset_manager_response["id"],
+        name: asset_manager_response["name"],
+        size: asset_manager_response["size"],
+        state: asset_manager_response["state"],
+      }
 
-    output[:file_url] = "#{asset_manager_response['file_url']}?token=#{asset[:auth_bypass_ids].first}" if asset[:auth_bypass_ids]
-    output[:preview_expiry] = asset[:auth_bypass_ids_expiry].iso8601 if asset[:auth_bypass_ids_expiry]
+      output[:file_url] = "#{asset_manager_response['file_url']}?token=#{asset[:auth_bypass_ids].first}" if asset[:auth_bypass_ids]
+      output[:preview_expiry] = asset[:auth_bypass_ids_expiry].iso8601 if asset[:auth_bypass_ids_expiry]
 
-    respond_to do |format|
-      format.json do
-        render status: :created, json: output
+      respond_to do |format|
+        format.json do
+          render status: :created, json: output
+        end
       end
+    rescue ActionController::UnknownFormat
+      error :not_acceptable, "Invalid Accept header"
+    rescue GdsApi::HTTPPayloadTooLarge
+      error :content_too_large, "Content exceeds maximum permitted size"
     end
-  rescue ActionController::UnknownFormat
-    error :not_acceptable, "Invalid Accept header"
   end
 
 private

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -42,6 +42,8 @@ class AssetsController < ApplicationController
       error :not_acceptable, "Invalid Accept header"
     rescue GdsApi::HTTPPayloadTooLarge
       error :content_too_large, "Content exceeds maximum permitted size"
+    rescue GdsApi::HTTPUnprocessableEntity => e
+      error :unprocessable_entity, e.message
     end
   end
 

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,0 +1,9 @@
+class AssetsController < ApplicationController
+  def create
+    respond_to do |format|
+      format.json do
+        render json: {}
+      end
+    end
+  end
+end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,9 +1,51 @@
 class AssetsController < ApplicationController
+  before_action :check_content_type_is_multipart
+
   def create
+    asset = {
+      file: asset_params[:file].tempfile,
+    }
+
+    asset_manager_response = Services.asset_manager.create_asset(asset).to_h
+
     respond_to do |format|
       format.json do
-        render json: {}
+        render status: :created, json: {
+          _response_info: {
+            status: "ok",
+          },
+          asset_id: get_asset_id_from_url(asset_manager_response["file_url"]),
+          content_type: asset_manager_response["content_type"],
+          deleted: asset_manager_response["deleted"],
+          draft: asset_manager_response["draft"],
+          file_url: asset_manager_response["file_url"],
+          id: asset_manager_response["id"],
+          name: asset_manager_response["name"],
+          size: asset_manager_response["size"],
+          state: asset_manager_response["state"],
+        }
       end
     end
+  rescue ActionController::UnknownFormat
+    error :not_acceptable, "Invalid Accept header"
+  end
+
+private
+
+  def check_content_type_is_multipart
+    unless request.headers["Content-Type"].match?(/^multipart\/form-data/)
+      error :unsupported_media_type, "Invalid Content-Type header"
+    end
+  end
+
+  def asset_params
+    params.require(:asset).permit(
+      :file,
+      :draft,
+    )
+  end
+
+  def get_asset_id_from_url(url)
+    url[/\/media\/(.*)\//, 1]
   end
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -14,13 +14,13 @@ class ManualsController < ApplicationController
         end
       end
     rescue ActionController::UnknownFormat
-      render json: { status: "error", errors: "Invalid Accept header" }, status: :not_acceptable
+      error :not_acceptable, "Invalid Accept header"
     rescue GdsApi::HTTPConflict => e
-      render json: { status: "error", errors: e }, status: :conflict
+      error :conflict, e
     rescue GdsApi::HTTPUnprocessableEntity => e
-      render json: { status: "error", errors: e }, status: :unprocessable_entity
+      error :unprocessable_entity, e
     rescue ValidationError
-      render json: { status: "error", errors: manual.errors.full_messages }, status: :unprocessable_entity
+      error :unprocessable_entity, manual.errors.full_messages
     end
   end
 end

--- a/app/controllers/manuals_controller.rb
+++ b/app/controllers/manuals_controller.rb
@@ -1,4 +1,5 @@
 class ManualsController < ApplicationController
+  before_action :check_content_type_is_json
   before_action :parse_request_body, only: [:update]
 
   def update

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -15,13 +15,13 @@ class SectionsController < ApplicationController
         end
       end
     rescue ActionController::UnknownFormat
-      render json: { status: "error", errors: "Invalid Accept header" }, status: :not_acceptable
+      error :not_acceptable, "Invalid Accept header"
     rescue GdsApi::HTTPConflict => e
-      render json: { status: "error", errors: e }, status: :conflict
+      error :conflict, e
     rescue GdsApi::HTTPUnprocessableEntity => e
-      render json: { status: "error", errors: e }, status: :unprocessable_entity
+      error :unprocessable_entity, e
     rescue ValidationError
-      render json: { status: "error", errors: section.errors.full_messages }, status: :unprocessable_entity
+      error :unprocessable_entity, section.errors.full_messages
     end
   end
 end

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,4 +1,5 @@
 class SectionsController < ApplicationController
+  before_action :check_content_type_is_json
   before_action :parse_request_body, only: [:update]
 
   def update

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -17,7 +17,7 @@ module Services
       @asset_manager ||= GdsApi::AssetManager.new(
         Plek.find("asset-manager"),
         bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"] || "example",
-        timeout: 10,
+        timeout: 60,
       )
     else
       Rails.logger.warn("Asset Manager requests are disabled in this environment")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
         resources :sections
       end
     end
+
+    resources :assets, only: [:create]
   end
 end

--- a/spec/fixtures/files/asset.txt
+++ b/spec/fixtures/files/asset.txt
@@ -1,0 +1,1 @@
+test-file

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -2,14 +2,67 @@ require "rails_helper"
 
 describe "assets resource" do
   describe "POST /assets" do
-    subject do
-      post_multipart "/assets", {}
+    let(:asset_manager_response) do
+      {
+        _response_info: {
+          status: "ok",
+        },
+        content_type: "text",
+        deleted: "false",
+        draft: "false",
+        file_url: "http://asset-manager.dev.gov.uk/media/45678/asset.txt",
+        id: "123",
+        name: "asset.txt",
+        size: "12",
+        state: "clean",
+      }
     end
 
-    it "responds with ok" do
-      subject
+    subject do
+      post_multipart "/assets", {
+        asset: {
+          file: fixture_file_upload("asset.txt", "text/plain"),
+        },
+      }
+    end
 
-      expect(response.status).to eq(200)
+    before do
+      allow(Services.asset_manager).to receive(:create_asset).and_return(asset_manager_response.deep_stringify_keys)
+    end
+
+    context "when Asset Manager responds with ok" do
+      it "responds with 201 Created" do
+        subject
+
+        expect(response.status).to eq(201)
+      end
+
+      it "responds with data from asset manager" do
+        subject
+
+        parsed_response = JSON.parse(response.body).deep_symbolize_keys
+        expect(parsed_response).to include(asset_manager_response)
+        expect(parsed_response).to include(asset_id: "45678")
+      end
+    end
+
+    it "errors if the Accept header is not application/json" do
+      post_multipart "/assets", {
+        asset: {
+          file: fixture_file_upload("asset.txt", "text/plain"),
+        },
+      }, { "HTTP_ACCEPT" => "text/plain" }
+      expect(response.status).to eq(406)
+    end
+
+    it "errors if the Content-Type header is not multipart/form-data" do
+      post "/assets", params: {}, headers: {
+        "CONTENT_TYPE" => "application/json",
+        "HTTP_ACCEPT" => "application/json",
+        "HTTP_AUTHORIZATION" => "Bearer 12345678",
+      }
+
+      expect(response.status).to eq(415)
     end
   end
 end

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -116,6 +116,19 @@ describe "assets resource" do
       end
     end
 
+    context "when Asset Manager responds with GdsApi::HTTPUnprocessableEntity" do
+      before do
+        allow(Services.asset_manager).to receive(:create_asset).and_raise(GdsApi::HTTPUnprocessableEntity.new(422, "Some error message"))
+      end
+
+      it "returns a 422 response" do
+        subject
+
+        expect(response.status).to eq(422)
+        expect(response.body).to include("Some error message")
+      end
+    end
+
     it "errors if the Accept header is not application/json" do
       allow(Services.asset_manager).to receive(:create_asset).and_return(asset_manager_response.deep_stringify_keys)
 

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -29,11 +29,11 @@ describe "assets resource" do
       }
     end
 
-    before do
-      allow(Services.asset_manager).to receive(:create_asset).and_return(asset_manager_response.deep_stringify_keys)
-    end
-
     context "when Asset Manager responds with ok" do
+      before do
+        allow(Services.asset_manager).to receive(:create_asset).and_return(asset_manager_response.deep_stringify_keys)
+      end
+
       context "when the asset is not draft" do
         let(:draft) { false }
 
@@ -103,7 +103,22 @@ describe "assets resource" do
       end
     end
 
+    context "when Asset Manager responds with GdsApi::HTTPPayloadTooLarge" do
+      before do
+        allow(Services.asset_manager).to receive(:create_asset).and_raise(GdsApi::HTTPPayloadTooLarge.new(413))
+      end
+
+      it "returns a 413 response" do
+        subject
+
+        expect(response.status).to eq(413)
+        expect(response.body).to include("Content exceeds maximum permitted size")
+      end
+    end
+
     it "errors if the Accept header is not application/json" do
+      allow(Services.asset_manager).to receive(:create_asset).and_return(asset_manager_response.deep_stringify_keys)
+
       post_multipart "/assets", {
         asset: {
           file: fixture_file_upload("asset.txt", "text/plain"),

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe "assets resource" do
+  describe "POST /assets" do
+    subject do
+      post_multipart "/assets", {}
+    end
+
+    it "responds with ok" do
+      subject
+
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 describe "assets resource" do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe "POST /assets" do
+    let(:draft) { true }
     let(:asset_manager_response) do
       {
         _response_info: {
@@ -9,7 +12,7 @@ describe "assets resource" do
         },
         content_type: "text",
         deleted: "false",
-        draft: "false",
+        draft: draft.to_s,
         file_url: "http://asset-manager.dev.gov.uk/media/45678/asset.txt",
         id: "123",
         name: "asset.txt",
@@ -31,18 +34,72 @@ describe "assets resource" do
     end
 
     context "when Asset Manager responds with ok" do
-      it "responds with 201 Created" do
-        subject
+      context "when the asset is not draft" do
+        let(:draft) { false }
 
-        expect(response.status).to eq(201)
+        subject do
+          post_multipart "/assets", {
+            asset: {
+              file: fixture_file_upload("asset.txt", "text/plain"),
+              draft: false,
+            },
+          }
+        end
+        it "responds with 201 Created" do
+          subject
+
+          expect(response.status).to eq(201)
+        end
+
+        it "responds with data from asset manager" do
+          subject
+
+          parsed_response = JSON.parse(response.body).deep_symbolize_keys
+          expect(parsed_response).to include(asset_manager_response)
+          expect(parsed_response).to include(asset_id: "45678")
+        end
+
+        it "does not include a token in the file_url" do
+          subject
+
+          parsed_response = JSON.parse(response.body).deep_symbolize_keys
+          expect(parsed_response[:file_url]).not_to match(/token=/)
+        end
       end
 
-      it "responds with data from asset manager" do
-        subject
+      context "when the asset is draft" do
+        before do
+          allow(SecureRandom).to receive(:uuid).and_return("some-token")
+        end
 
-        parsed_response = JSON.parse(response.body).deep_symbolize_keys
-        expect(parsed_response).to include(asset_manager_response)
-        expect(parsed_response).to include(asset_id: "45678")
+        it "responds with 201 Created" do
+          subject
+
+          expect(response.status).to eq(201)
+        end
+
+        it "responds with data from asset manager" do
+          subject
+
+          parsed_response = JSON.parse(response.body).deep_symbolize_keys
+          expect(parsed_response).to include(asset_manager_response.except(:file_url))
+          expect(parsed_response).to include(asset_id: "45678")
+        end
+
+        it "generates and includes a token in the file_url" do
+          subject
+
+          parsed_response = JSON.parse(response.body).deep_symbolize_keys
+          expect(parsed_response).to include(file_url: "http://asset-manager.dev.gov.uk/media/45678/asset.txt?token=some-token")
+        end
+
+        it "includes a preview expiry date 30 days in the future" do
+          travel_to Time.zone.local(2026, 1, 1, 0, 0, 1)
+          subject
+
+          parsed_response = JSON.parse(response.body).deep_symbolize_keys
+          expect(parsed_response).to include(preview_expiry: Time.zone.local(2026, 1, 31, 0, 0, 1).iso8601)
+        end
       end
     end
 

--- a/spec/support/json_request_helpers.rb
+++ b/spec/support/json_request_helpers.rb
@@ -1,10 +1,20 @@
 module JSONRequestHelper
+  def post_multipart(path, attrs, headers = {})
+    default_headers = {
+      "HTTP_ACCEPT" => "application/json",
+      "HTTP_AUTHORIZATION" => "Bearer 12345678",
+    }
+
+    post path, params: attrs, headers: default_headers.merge(headers), as: :multipart
+  end
+
   def put_json(path, attrs, headers = {})
     default_headers = {
       "CONTENT_TYPE" => "application/json",
       "HTTP_ACCEPT" => "application/json",
       "HTTP_AUTHORIZATION" => "Bearer 12345678",
     }
+
     put path, params: attrs.to_json, headers: default_headers.merge(headers)
   end
 


### PR DESCRIPTION
This implements the create asset endpoint detailed in [the API documentation](https://github.com/alphagov/hmrc-manuals-api/blob/main/docs/upload-and-manage-assets.md#upload-new-asset).

It allows both live and draft assets to be uploaded, then passed onto Asset Manager.

Requires https://github.com/alphagov/asset-manager/pull/2012.