### PR TITLE
Add an Asset Manager service

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,6 +1,7 @@
 require "gds_api/publishing_api"
 require "gds_api/search"
 require "gds_api/content_store"
+require "gds_api/asset_manager"
 
 module Services
   def self.publishing_api
@@ -9,6 +10,18 @@ module Services
       bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
       timeout: 10,
     )
+  end
+
+  def self.asset_manager
+    if Rails.configuration.allow_asset_manager_requests
+      @asset_manager ||= GdsApi::AssetManager.new(
+        Plek.find("asset-manager"),
+        bearer_token: ENV["ASSET_MANAGER_BEARER_TOKEN"] || "example",
+        timeout: 10,
+      )
+    else
+      Rails.logger.warn("Asset Manager requests are disabled in this environment")
+    end
   end
 
   def self.search_api

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module HmrcManualsApi
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.middleware.insert_after(Rack::Runtime, Rack::MethodOverride)
+
+    config.allow_asset_manager_requests = ENV.fetch("ALLOW_ASSET_MANAGER_REQUESTS", false)
   end
 end


### PR DESCRIPTION
Add a service method to allow connections to Asset Manager. This is currently gated behind a feature flag, with the intention that this feature only be used in integration for now. The plan is to remove that at a later date.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
