### PR TITLE
[PP-7887] Add endpoint to get Asset Metadata

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -1,5 +1,5 @@
 class AssetsController < ApplicationController
-  before_action :check_content_type_is_multipart
+  before_action :check_content_type_is_multipart, only: [:create]
 
   def create
     asset = {
@@ -45,6 +45,10 @@ class AssetsController < ApplicationController
     rescue GdsApi::HTTPUnprocessableEntity => e
       error :unprocessable_entity, e.message
     end
+  end
+
+  def show
+    render json: {}
   end
 
 private

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -48,7 +48,14 @@ class AssetsController < ApplicationController
   end
 
   def show
-    render json: {}
+    asset_manager_response = Services.asset_manager.asset(params[:id]).to_h
+    asset_manager_response.merge!({ asset_id: get_asset_id_from_url(asset_manager_response["file_url"]) })
+
+    render json: asset_manager_response
+  rescue GdsApi::HTTPNotFound
+    error :not_found, "Asset not found"
+  rescue GdsApi::HTTPForbidden
+    error :forbidden, "Access to asset is forbidden"
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,6 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :assets, only: [:create]
+    resources :assets, only: %i[create show]
   end
 end

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -3,6 +3,18 @@ require "rails_helper"
 describe "assets resource" do
   include ActiveSupport::Testing::TimeHelpers
 
+  describe "GET /assets/:id" do
+    subject do
+      get "/assets/123456"
+    end
+
+    it "responds with 200" do
+      subject
+
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe "POST /assets" do
     let(:draft) { true }
     let(:asset_manager_response) do

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -4,14 +4,71 @@ describe "assets resource" do
   include ActiveSupport::Testing::TimeHelpers
 
   describe "GET /assets/:id" do
-    subject do
-      get "/assets/123456"
+    let(:asset_manager_response) do
+      {
+        _response_info: {
+          status: "ok",
+        },
+        content_type: "text",
+        deleted: "false",
+        draft: "false",
+        file_url: "http://asset-manager.dev.gov.uk/media/123456789/asset.txt",
+        id: "http://asset-manager/assets/123456789",
+        name: "asset.txt",
+        size: "12",
+        state: "clean",
+      }
     end
 
-    it "responds with 200" do
-      subject
+    subject do
+      get "/assets/123456789"
+    end
 
-      expect(response.status).to eq(200)
+    context "when asset manager responds with ok" do
+      before do
+        allow(Services.asset_manager).to receive(:asset).and_return(asset_manager_response.deep_stringify_keys)
+      end
+
+      it "responds with 200" do
+        subject
+
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with data from asset manager" do
+        subject
+
+        parsed_response = JSON.parse(response.body).deep_symbolize_keys
+
+        expect(parsed_response).to include(asset_manager_response)
+        expect(parsed_response).to include(asset_id: "123456789")
+      end
+    end
+
+    context "when asset manager responds with GdsApi::HTTPNotFound" do
+      before do
+        allow(Services.asset_manager).to receive(:asset).and_raise(GdsApi::HTTPNotFound.new(404))
+      end
+
+      it "responds with 404" do
+        subject
+
+        expect(response.status).to eq(404)
+        expect(response.body).to include("Asset not found")
+      end
+    end
+
+    context "when asset manager responds with GdsApi::HTTPForbidden" do
+      before do
+        allow(Services.asset_manager).to receive(:asset).and_raise(GdsApi::HTTPForbidden.new(403))
+      end
+
+      it "responds with 403" do
+        subject
+
+        expect(response.status).to eq(403)
+        expect(response.body).to include("Access to asset is forbidden")
+      end
     end
   end
 


### PR DESCRIPTION
This PR implements the GET asset endpoint detailed in [the API documentation](https://github.com/alphagov/hmrc-manuals-api/blob/main/docs/upload-and-manage-assets.md#upload-new-asset)

It allows HMRC Manuals API to retrieve Metadata about (currently) any asset in Asset Manager

Further revision to this may happen based on [this card](https://gov-uk.atlassian.net/jira/software/c/projects/PP/boards/398?selectedIssue=PP-7924)

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
