### PR TITLE
Delegate response to Asset Manager

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -13,24 +13,9 @@ class AssetsController < ApplicationController
     end
 
     begin
-      asset_manager_response = Services.asset_manager.create_asset(asset).to_h
+      output = formatted_asset_manager_response(Services.asset_manager.create_asset(asset))
 
-      output = {
-        _response_info: {
-          status: "ok",
-        },
-        asset_id: get_asset_id_from_url(asset_manager_response["file_url"]),
-        content_type: asset_manager_response["content_type"],
-        deleted: asset_manager_response["deleted"],
-        draft: asset_manager_response["draft"],
-        file_url: asset_manager_response["file_url"],
-        id: asset_manager_response["id"],
-        name: asset_manager_response["name"],
-        size: asset_manager_response["size"],
-        state: asset_manager_response["state"],
-      }
-
-      output[:file_url] = "#{asset_manager_response['file_url']}?token=#{asset[:auth_bypass_ids].first}" if asset[:auth_bypass_ids]
+      output[:file_url] = "#{output['file_url']}?token=#{asset[:auth_bypass_ids].first}" if asset[:auth_bypass_ids]
       output[:preview_expiry] = asset[:auth_bypass_ids_expiry].iso8601 if asset[:auth_bypass_ids_expiry]
 
       respond_to do |format|
@@ -48,10 +33,9 @@ class AssetsController < ApplicationController
   end
 
   def show
-    asset_manager_response = Services.asset_manager.asset(params[:id]).to_h
-    asset_manager_response.merge!({ asset_id: get_asset_id_from_url(asset_manager_response["file_url"]) })
+    output = formatted_asset_manager_response(Services.asset_manager.asset(params[:id]))
 
-    render json: asset_manager_response
+    render json: output
   rescue GdsApi::HTTPNotFound
     error :not_found, "Asset not found"
   rescue GdsApi::HTTPForbidden
@@ -70,6 +54,12 @@ private
     params.require(:asset).permit(
       :file,
       :draft,
+    )
+  end
+
+  def formatted_asset_manager_response(asset_manager_response)
+    asset_manager_response.to_h.merge(
+      { asset_id: get_asset_id_from_url(asset_manager_response["file_url"]) },
     )
   end
 


### PR DESCRIPTION
In https://github.com/alphagov/hmrc-manuals-api/pull/1323, we made the decision to delegate the asset management response fields to Asset Manager, to avoid duplication of code between the two apps.

This does the same for the create asset endpoint, and moves the code into a shared helper.