### PR TITLE
[PP-7889] Add endpoint to regenerate an asset's access token

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -7,16 +7,15 @@ class AssetsController < ApplicationController
       file: asset_params[:file].tempfile,
     }
 
-    if asset[:draft]
-      asset[:auth_bypass_ids] = [SecureRandom.uuid]
-      asset[:auth_bypass_ids_expiry] = Time.zone.now + 30.days
-    end
+    asset.merge!(asset_auth_params) if asset[:draft]
 
     begin
-      output = formatted_asset_manager_response(Services.asset_manager.create_asset(asset))
-
-      output[:file_url] = "#{output['file_url']}?token=#{asset[:auth_bypass_ids].first}" if asset[:auth_bypass_ids]
-      output[:preview_expiry] = asset[:auth_bypass_ids_expiry].iso8601 if asset[:auth_bypass_ids_expiry]
+      asset_manager_response = Services.asset_manager.create_asset(asset)
+      output = if asset[:draft]
+                 formatted_asset_manager_response_for_draft(asset_manager_response, asset)
+               else
+                 formatted_asset_manager_response(asset_manager_response)
+               end
 
       respond_to do |format|
         format.json do
@@ -63,7 +62,21 @@ private
     )
   end
 
+  def formatted_asset_manager_response_for_draft(asset_manager_response, asset_params)
+    formatted_asset_manager_response(asset_manager_response).merge(
+      file_url: "#{asset_manager_response['file_url']}?token=#{asset_params[:auth_bypass_ids].first}",
+      preview_expiry: asset_params[:auth_bypass_ids_expiry].iso8601,
+    )
+  end
+
   def get_asset_id_from_url(url)
     url[/\/media\/(.*)\//, 1]
+  end
+
+  def asset_auth_params
+    {
+      auth_bypass_ids: [SecureRandom.uuid],
+      auth_bypass_ids_expiry: Time.zone.now + 30.days,
+    }
   end
 end

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -41,6 +41,17 @@ class AssetsController < ApplicationController
     error :forbidden, "Access to asset is forbidden"
   end
 
+  def regenerate_access
+    asset_manager_response = Services.asset_manager.update_asset(params[:asset_id], asset_auth_params)
+    output = formatted_asset_manager_response_for_draft(asset_manager_response, asset_auth_params)
+
+    render status: :created, json: output
+  rescue GdsApi::HTTPNotFound
+    error :not_found, "Asset not found"
+  rescue GdsApi::HTTPForbidden
+    error :forbidden, "Access to asset is forbidden"
+  end
+
 private
 
   def check_content_type_is_multipart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :assets, only: %i[create show]
+    resources :assets, only: %i[create show] do
+      post "regenerate-access", action: :regenerate_access, on: :member
+    end
   end
 end

--- a/spec/requests/assets_spec.rb
+++ b/spec/requests/assets_spec.rb
@@ -219,4 +219,87 @@ describe "assets resource" do
       expect(response.status).to eq(415)
     end
   end
+
+  describe "POST /assets/:id/regenerate-access" do
+    let(:asset_manager_response) do
+      {
+        _response_info: {
+          status: "ok",
+        },
+        content_type: "text",
+        deleted: "false",
+        draft: "false",
+        file_url: "http://asset-manager.dev.gov.uk/media/123456789/asset.txt",
+        id: "http://asset-manager/assets/123456789",
+        name: "asset.txt",
+        size: "12",
+        state: "clean",
+      }
+    end
+
+    subject do
+      post "/assets/123456789/regenerate-access"
+    end
+
+    context "when asset manager responds with ok" do
+      before do
+        allow(Services.asset_manager).to receive(:update_asset).and_return(asset_manager_response.deep_stringify_keys)
+        allow(SecureRandom).to receive(:uuid).and_return("new-token")
+      end
+
+      it "responds with 201" do
+        subject
+
+        expect(response.status).to eq(201)
+      end
+
+      it "responds with data from asset manager" do
+        subject
+
+        parsed_response = JSON.parse(response.body).deep_symbolize_keys
+        expect(parsed_response).to include(asset_manager_response.except(:file_url))
+      end
+
+      it "generates and includes a token in the file_url" do
+        subject
+
+        parsed_response = JSON.parse(response.body).deep_symbolize_keys
+        expect(parsed_response).to include(file_url: "http://asset-manager.dev.gov.uk/media/123456789/asset.txt?token=new-token")
+      end
+
+      it "includes a preview expiry date 30 days in the future" do
+        travel_to Time.zone.local(2026, 1, 1, 0, 0, 1)
+        subject
+
+        parsed_response = JSON.parse(response.body).deep_symbolize_keys
+        expect(parsed_response).to include(preview_expiry: Time.zone.local(2026, 1, 31, 0, 0, 1).iso8601)
+      end
+    end
+
+    context "when asset manager responds with GdsApi::HTTPNotFound" do
+      before do
+        allow(Services.asset_manager).to receive(:update_asset).and_raise(GdsApi::HTTPNotFound.new(404))
+      end
+
+      it "responds with 404" do
+        subject
+
+        expect(response.status).to eq(404)
+        expect(response.body).to include("Asset not found")
+      end
+    end
+
+    context "when asset manager responds with GdsApi::HTTPForbidden" do
+      before do
+        allow(Services.asset_manager).to receive(:update_asset).and_raise(GdsApi::HTTPForbidden.new(403))
+      end
+
+      it "responds with 403" do
+        subject
+
+        expect(response.status).to eq(403)
+        expect(response.body).to include("Access to asset is forbidden")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This will allow HMRC to request a new access token for draft assets, when their existing one expires or they need to expire the old token.

Implemented in accordance with the [draft API documentation](https://github.com/alphagov/hmrc-manuals-api/blob/main/docs/upload-and-manage-assets.md#regenerate-draft-asset-access).